### PR TITLE
Minimal cut sets brute force

### DIFF
--- a/repyability/__init__.py
+++ b/repyability/__init__.py
@@ -1,1 +1,1 @@
-from .rbd.rbd import RBD
+from .rbd.rbd import RBD  # noqa: F401

--- a/repyability/rbd/min_cut_sets.py
+++ b/repyability/rbd/min_cut_sets.py
@@ -1,0 +1,71 @@
+from itertools import combinations
+from typing import Hashable
+
+import networkx as nx
+
+
+def min_cut_sets(
+    G: nx.DiGraph, input_node: Hashable, output_node: Hashable
+) -> set[frozenset[Hashable]]:
+    """Returns the set of minimal cut-sets of a graph
+
+    Note: doesn't consider k-out-of-n nodes
+
+    Parameters
+    ----------
+    G : nx.DiGraph
+        The graph in question
+    input_node : Hashable
+        The input/source node
+    output_node : Hashable
+        The output/sink node
+
+    Returns
+    -------
+    set[frozenset[Hashable]]
+        The set of minimal nodal cut-sets, i.e. if any of these node-sets
+        fail, then the system fails
+    """
+    # Get all possible node subsets (excluding input and output nodes)
+    intermediate_nodes = set(G.nodes()) - {input_node, output_node}
+    node_sets = get_all_node_subsets(intermediate_nodes)
+
+    # For each node_subset, create a copy of graph G with these nodes removed
+    # If input_node->output_node has no path then add it to the cut_sets set
+    # But if there are any supersets of this cut-set, then those supersets
+    # are not minimal cut-sets, so remove them
+
+    # The set of cut-sets (not necessarily minimal cut-sets)
+    cut_sets: set[frozenset] = set()
+
+    # Check if the node-set is a cut-set
+    for node_set in node_sets:
+        # Create a copy of G with node_subset nodes removed
+        H = G.copy()
+        H.remove_nodes_from(node_set)
+
+        # Check if the node-set is a cut-set
+        if not nx.has_path(H, input_node, output_node):
+            # If it is, check that there are no supersets of it in cut_sets
+            # because if there are they are definitely not minimal cut-sets
+            # and should be removed
+            for cut_set in cut_sets.copy():
+                if node_set.issubset(cut_set):
+                    cut_sets.remove(cut_set)
+
+            # Finally add the node-set to the set of cut-sets
+            cut_sets.add(node_set)
+
+    # By now all the non-minimal cut-sets have been removed, so its safe to say
+    # that cut_sets is the set of all minimal_cut_sets
+    minimal_cut_sets = cut_sets
+
+    return minimal_cut_sets
+
+
+def get_all_node_subsets(nodes: set[Hashable]) -> list[frozenset[Hashable]]:
+    node_subsets = []
+    for i in range(len(nodes), 0, -1):
+        for comb in list(combinations(nodes, i)):
+            node_subsets.append(frozenset(comb))
+    return node_subsets

--- a/repyability/rbd/rbd.py
+++ b/repyability/rbd/rbd.py
@@ -10,6 +10,7 @@ import surpyval as surv
 from numpy.typing import ArrayLike
 
 from .helper_classes import PerfectReliability, PerfectUnreliability
+from .min_cut_sets import min_cut_sets
 
 
 class RBD:
@@ -113,8 +114,7 @@ class RBD:
         set contains the frozenset of nodes. frozensets were used so the inner
         set elements could be hashable.
         """
-        # Just to show test asserts work (for test_rbd_min_cut_sets_rbd_series)
-        return set({frozenset([2]), frozenset([3]), frozenset([4])})
+        return min_cut_sets(self.G, self.input_node, self.output_node)
 
     def sf(
         self,

--- a/repyability/rbd/rbd.py
+++ b/repyability/rbd/rbd.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from copy import copy
 from itertools import combinations
-from typing import Any, Hashable, Iterable
+from typing import Any, Collection, Hashable, Iterable
 from warnings import warn
 
 import networkx as nx
@@ -107,13 +107,22 @@ class RBD:
             self.G, source=self.input_node, target=self.output_node
         )
 
+    def get_min_cut_sets(self) -> set[frozenset[Hashable]]:
+        """
+        Returns the set of frozensets of minimal cut sets of the RBD. The outer
+        set contains the frozenset of nodes. frozensets were used so the inner
+        set elements could be hashable.
+        """
+        # Just to show test asserts work (for test_rbd_min_cut_sets_rbd_series)
+        return set({frozenset([2]), frozenset([3]), frozenset([4])})
+
     def sf(
         self,
         x: ArrayLike,
-        working_nodes: Iterable[Hashable] = [],
-        broken_nodes: Iterable[Hashable] = [],
-        working_components: Iterable[Hashable] = [],
-        broken_components: Iterable[Hashable] = [],
+        working_nodes: Collection[Hashable] = [],
+        broken_nodes: Collection[Hashable] = [],
+        working_components: Collection[Hashable] = [],
+        broken_components: Collection[Hashable] = [],
     ) -> np.ndarray:
         """Returns the system reliability for time/s x.
 
@@ -121,13 +130,13 @@ class RBD:
         ----------
         x : ArrayLike
             Time/s as a number or iterable
-        working_nodes : Iterable[Hashable], optional
+        working_nodes : Collection[Hashable], optional
             Marks these nodes as perfectly reliable, by default []
-        broken_nodes : Iterable[Hashable], optional
+        broken_nodes : Collection[Hashable], optional
             Marks these nodes as perfectly unreliable, by default []
-        working_components : Iterable[Hashable], optional
+        working_components : Collection[Hashable], optional
             Marks these components as perfectly reliable, by default []
-        broken_components : Iterable[Hashable], optional
+        broken_components : Collection[Hashable], optional
             Marks these components as perfectly unreliable, by default []
 
         Returns
@@ -151,7 +160,7 @@ class RBD:
             )
 
         # Check for any node/component argument inconsistency
-        argument_nodes = set()
+        argument_nodes: set[object] = set()
         argument_nodes.update(working_nodes)
         argument_nodes.update(broken_nodes)
         number_of_arg_comp_nodes = 0

--- a/repyability/tests/test_rbd.py
+++ b/repyability/tests/test_rbd.py
@@ -169,7 +169,7 @@ def rbd_repeated_component_composite() -> RBD:
     An RBD with three intermediate nodes, two of them a repeated component.
     """
     nodes = {1: "input_node", 2: 2, 3: 2, 4: 3, 5: "output_node"}
-    edges = [[1, 2], [1, 3], [2, 5], [3, 4], [4, 5]]
+    edges = [(1, 2), (1, 3), (2, 5), (3, 4), (4, 5)]
     components = {
         2: FixedProbabilityFitter.from_params(0.8),
         3: FixedProbabilityFitter.from_params(0.5),
@@ -210,6 +210,47 @@ def test_rbd_sf_series(rbd_series: RBD):
         )
         == rbd_series.sf(t)[0]
     )
+
+
+# Test get_min_cut_sets()
+
+
+def test_rbd_get_min_cut_sets_rbd_series(rbd_series: RBD):
+    assert {
+        frozenset([2]),
+        frozenset([3]),
+        frozenset([4]),
+    } == rbd_series.get_min_cut_sets()
+
+
+def test_rbd_get_min_cut_sets_rbd_parallel(rbd_parallel: RBD):
+    assert {frozenset([2, 3, 4])} == rbd_parallel.get_min_cut_sets()
+
+
+def test_rbd_get_min_cut_sets_rbd1(rbd1: RBD):
+    assert {
+        frozenset(["pump1", "pump2"]),
+        frozenset(["valve"]),
+    } == rbd1.get_min_cut_sets()
+
+
+def test_rbd_get_min_cut_sets_rbd2(rbd2: RBD):
+    assert {
+        frozenset([2]),
+        frozenset([3, 4]),
+        frozenset([4, 5]),
+        frozenset([4, 6]),
+        frozenset([7]),
+    } == rbd2.get_min_cut_sets()
+
+
+def test_rbd_get_min_cut_sets_rbd3(rbd3: RBD):
+    assert {
+        frozenset([1, 3]),
+        frozenset([2, 4]),
+        frozenset([1, 4, 5]),
+        frozenset([2, 3, 5]),
+    } == rbd3.get_min_cut_sets()
 
 
 # Test sf() w/ simple series RBD


### PR DESCRIPTION
- Implemented brute-force method for obtaining the set of minimal cut-sets of an RBD (assuming no koon nodes)
- Added tests for ^
- Suppressed flake8 complaint about `reparability/__init__.py`
- Fixed some type hint / Mypy issues