### PR TITLE
Fussel-Vesely and Minimal Path-Sets

### DIFF
--- a/repyability/rbd/rbd.py
+++ b/repyability/rbd/rbd.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from copy import copy
 from itertools import combinations
-from typing import Any, Collection, Hashable, Iterable
+from typing import Any, Collection, Hashable, Iterable, Iterator
 from warnings import warn
 
 import networkx as nx
@@ -101,9 +101,17 @@ class RBD:
         self.components = components
         self.nodes = nodes
 
-    def all_path_sets(self):
-        # For a very large RBD, this seems expensive; O(n!).....
-        # Need to convert to a fault tree using graph algs
+    def get_all_path_sets(self) -> Iterator[list[Hashable]]:
+        """Gets all path sets from input_node to output_node
+
+        Really just wraps networkx.all_simple_paths(). This is an expensive
+        operation, so be careful using for very large RBDs.
+
+        Returns
+        -------
+        Iterator[list[Hashable]]
+            The iterator of paths
+        """
         return nx.all_simple_paths(
             self.G, source=self.input_node, target=self.output_node
         )
@@ -216,7 +224,7 @@ class RBD:
         x = np.atleast_1d(x)
 
         # Get all path sets
-        paths = list(self.all_path_sets())
+        paths = list(self.get_all_path_sets())
         num_paths = len(paths)
 
         # Cache all component reliabilities for efficiency

--- a/repyability/tests/test_rbd.py
+++ b/repyability/tests/test_rbd.py
@@ -554,7 +554,7 @@ def test_rbd_criticality_importance(rbd1: RBD):
 
 def test_fussel_vesely_c_rbd1(rbd1: RBD):
     t = 2
-    fv_importance = rbd1.fussel_vesely(t)
+    fv_importance = rbd1.fussel_vesely(t, fv_type="c")
     assert (
         pytest.approx(
             rbd1.components["pump1"].ff(t)
@@ -579,7 +579,7 @@ def test_fussel_vesely_c_rbd1(rbd1: RBD):
 
 def test_fussel_vesely_c_series(rbd_series: RBD):
     t = 2
-    fv_importance = rbd_series.fussel_vesely(t)
+    fv_importance = rbd_series.fussel_vesely(t, fv_type="c")
     assert (
         pytest.approx(rbd_series.components[2].ff(t) / rbd_series.ff(t))
         == fv_importance[2]
@@ -596,7 +596,7 @@ def test_fussel_vesely_c_series(rbd_series: RBD):
 
 def test_fussel_vesely_c_parallel(rbd_parallel: RBD):
     t = 2
-    fv_importance = rbd_parallel.fussel_vesely(t)
+    fv_importance = rbd_parallel.fussel_vesely(t, fv_type="c")
     fv_expected = (
         rbd_parallel.components[2].ff(t)
         * rbd_parallel.components[3].ff(t)
@@ -610,7 +610,7 @@ def test_fussel_vesely_c_parallel(rbd_parallel: RBD):
 
 def test_fussel_vesely_c_rbd2(rbd2: RBD):
     t = 2
-    fv_importance = rbd2.fussel_vesely(t)
+    fv_importance = rbd2.fussel_vesely(t, fv_type="c")
     assert (
         pytest.approx(rbd2.components[2].ff(t) / rbd2.ff(t))
         == fv_importance[2]
@@ -652,7 +652,7 @@ def test_fussel_vesely_c_rbd2(rbd2: RBD):
 
 def test_fussel_vesely_c_rbd3(rbd3: RBD):
     t = 2
-    fv_importance = rbd3.fussel_vesely(t)
+    fv_importance = rbd3.fussel_vesely(t, fv_type="c")
     assert (
         pytest.approx(
             (
@@ -722,7 +722,7 @@ def test_fussel_vesely_c_repeated_component_parallel(
 ):
     rbd = rbd_repeated_component_parallel
     t = 2
-    fv_importance = rbd.fussel_vesely(t)
+    fv_importance = rbd.fussel_vesely(t, fv_type="c")
     fv_expected = (
         rbd.components[2].ff(t)
         * rbd.components[3].ff(t)
@@ -740,7 +740,7 @@ def test_fussel_vesely_c_rbd_repeated_component_series(
 ):
     rbd = rbd_repeated_component_series
     t = 2
-    fv_importance = rbd.fussel_vesely(t)
+    fv_importance = rbd.fussel_vesely(t, fv_type="c")
     assert (
         pytest.approx(rbd.components[2].ff(t) / rbd.ff(t)) == fv_importance[2]
     )
@@ -757,7 +757,7 @@ def test_fussel_vesely_c_rbd_repeated_component_composite(
 ):
     rbd = rbd_repeated_component_composite
     t = 2
-    fv_importance = rbd.fussel_vesely(t)
+    fv_importance = rbd.fussel_vesely(t, fv_type="c")
     assert (
         pytest.approx(
             (

--- a/repyability/tests/test_rbd.py
+++ b/repyability/tests/test_rbd.py
@@ -234,6 +234,13 @@ def test_rbd_get_min_path_sets_rbd1(rbd1: RBD):
     } == rbd1.get_min_path_sets()
 
 
+def test_rbd_get_min_path_sets_rbd1_exclude_in_out_node(rbd1: RBD):
+    assert {
+        ("pump1", "valve"),
+        ("pump2", "valve"),
+    } == rbd1.get_min_path_sets(include_in_out_nodes=False)
+
+
 def test_rbd_get_min_path_sets_rbd2(rbd2: RBD):
     assert {(1, 2, 3, 5, 6, 7, 8), (1, 2, 4, 7, 8)} == rbd2.get_min_path_sets()
 
@@ -812,3 +819,270 @@ def test_fussel_vesely_c_rbd_repeated_component_composite(
         )
         == fv_importance[4]
     )
+
+
+# Test fussel_vesely() w/ path-set method
+
+
+def test_fussel_vesely_p_rbd1(rbd1: RBD):
+    t = 2
+    fv_importance = rbd1.fussel_vesely(t, fv_type="p")
+    assert (
+        pytest.approx(
+            rbd1.components["pump1"].ff(t)
+            * rbd1.components["valve"].ff(t)
+            / rbd1.ff(t)
+        )
+        == fv_importance["pump1"]
+    )
+    assert (
+        pytest.approx(
+            rbd1.components["pump2"].ff(t)
+            * rbd1.components["valve"].ff(t)
+            / rbd1.ff(t)
+        )
+        == fv_importance["pump2"]
+    )
+    assert (
+        pytest.approx(
+            (
+                rbd1.components["pump1"].ff(t) * rbd1.components["valve"].ff(t)
+                + rbd1.components["pump2"].ff(t)
+                * rbd1.components["valve"].ff(t)
+            )
+            / rbd1.ff(t)
+        )
+        == fv_importance["valve"]
+    )
+
+
+def test_fussel_vesely_p_series(rbd_series: RBD):
+    t = 2
+    fv_importance = rbd_series.fussel_vesely(t, fv_type="p")
+    expected_fv_importance = (
+        rbd_series.components[2].ff(t)
+        * rbd_series.components[3].ff(t)
+        * rbd_series.components[4].ff(t)
+        / rbd_series.ff(t)
+    )
+    assert pytest.approx(expected_fv_importance) == fv_importance[2]
+    assert pytest.approx(expected_fv_importance) == fv_importance[3]
+    assert pytest.approx(expected_fv_importance) == fv_importance[4]
+
+
+def test_fussel_vesely_p_parallel(rbd_parallel: RBD):
+    t = 2
+    fv_importance = rbd_parallel.fussel_vesely(t, fv_type="p")
+    assert (
+        pytest.approx(rbd_parallel.components[2].ff(t) / rbd_parallel.ff(t))
+        == fv_importance[2]
+    )
+    assert (
+        pytest.approx(rbd_parallel.components[3].ff(t) / rbd_parallel.ff(t))
+        == fv_importance[3]
+    )
+    assert (
+        pytest.approx(rbd_parallel.components[4].ff(t) / rbd_parallel.ff(t))
+        == fv_importance[4]
+    )
+
+
+def test_fussel_vesely_p_rbd2(rbd2: RBD):
+    t = 2
+    fv_importance = rbd2.fussel_vesely(t, fv_type="p")
+    assert (
+        pytest.approx(
+            (
+                (
+                    rbd2.components[2].ff(t)
+                    * rbd2.components[3].ff(t)
+                    * rbd2.components[5].ff(t)
+                    * rbd2.components[6].ff(t)
+                    * rbd2.components[7].ff(t)
+                )
+                + (
+                    rbd2.components[2].ff(t)
+                    * rbd2.components[4].ff(t)
+                    * rbd2.components[7].ff(t)
+                )
+            )
+            / rbd2.ff(t)
+        )
+        == fv_importance[2]
+    )
+    assert (
+        pytest.approx(
+            (
+                rbd2.components[2].ff(t)
+                * rbd2.components[3].ff(t)
+                * rbd2.components[5].ff(t)
+                * rbd2.components[6].ff(t)
+                * rbd2.components[7].ff(t)
+            )
+            / rbd2.ff(t)
+        )
+        == fv_importance[3]
+    )
+    assert (
+        pytest.approx(
+            (
+                rbd2.components[2].ff(t)
+                * rbd2.components[4].ff(t)
+                * rbd2.components[7].ff(t)
+            )
+            / rbd2.ff(t)
+        )
+        == fv_importance[4]
+    )
+    assert (
+        pytest.approx(
+            (
+                rbd2.components[2].ff(t)
+                * rbd2.components[3].ff(t)
+                * rbd2.components[5].ff(t)
+                * rbd2.components[6].ff(t)
+                * rbd2.components[7].ff(t)
+            )
+            / rbd2.ff(t)
+        )
+        == fv_importance[5]
+    )
+    assert (
+        pytest.approx(
+            (
+                rbd2.components[2].ff(t)
+                * rbd2.components[3].ff(t)
+                * rbd2.components[5].ff(t)
+                * rbd2.components[6].ff(t)
+                * rbd2.components[7].ff(t)
+            )
+            / rbd2.ff(t)
+        )
+        == fv_importance[6]
+    )
+    assert (
+        pytest.approx(
+            (
+                (
+                    rbd2.components[2].ff(t)
+                    * rbd2.components[3].ff(t)
+                    * rbd2.components[5].ff(t)
+                    * rbd2.components[6].ff(t)
+                    * rbd2.components[7].ff(t)
+                )
+                + (
+                    rbd2.components[2].ff(t)
+                    * rbd2.components[4].ff(t)
+                    * rbd2.components[7].ff(t)
+                )
+            )
+            / rbd2.ff(t)
+        )
+    ) == fv_importance[7]
+
+
+def test_fussel_vesely_p_rbd3(rbd3: RBD):
+    t = 2
+    fv_importance = rbd3.fussel_vesely(t, fv_type="p")
+    assert (
+        pytest.approx(
+            (
+                (rbd3.components[1].ff(t) * rbd3.components[2].ff(t))
+                + (
+                    rbd3.components[1].ff(t)
+                    * rbd3.components[5].ff(t)
+                    * rbd3.components[4].ff(t)
+                )
+            )
+            / rbd3.ff(t)
+        )
+        == fv_importance[1]
+    )
+    assert (
+        pytest.approx(
+            (
+                (rbd3.components[1].ff(t) * rbd3.components[2].ff(t))
+                + (
+                    rbd3.components[3].ff(t)
+                    * rbd3.components[5].ff(t)
+                    * rbd3.components[2].ff(t)
+                )
+            )
+            / rbd3.ff(t)
+        )
+        == fv_importance[2]
+    )
+    assert (
+        pytest.approx(
+            (
+                (rbd3.components[3].ff(t) * rbd3.components[4].ff(t))
+                + (
+                    rbd3.components[3].ff(t)
+                    * rbd3.components[5].ff(t)
+                    * rbd3.components[2].ff(t)
+                )
+            )
+            / rbd3.ff(t)
+        )
+        == fv_importance[3]
+    )
+    assert (
+        pytest.approx(
+            (
+                rbd3.components[3].ff(t) * rbd3.components[4].ff(t)
+                + rbd3.components[1].ff(t)
+                * rbd3.components[4].ff(t)
+                * rbd3.components[5].ff(t)
+            )
+            / rbd3.ff(t)
+        )
+        == fv_importance[4]
+    )
+    assert (
+        pytest.approx(
+            (
+                rbd3.components[1].ff(t)
+                * rbd3.components[5].ff(t)
+                * rbd3.components[4].ff(t)
+                + rbd3.components[3].ff(t)
+                * rbd3.components[5].ff(t)
+                * rbd3.components[2].ff(t)
+            )
+            / rbd3.ff(t)
+        )
+        == fv_importance[5]
+    )
+
+
+def test_fussel_vesely_p_repeated_component_parallel(
+    rbd_repeated_component_parallel: RBD,
+):
+    rbd = rbd_repeated_component_parallel
+    t = 2
+    fv_importance = rbd.fussel_vesely(t, fv_type="p")
+    assert (
+        pytest.approx(rbd.components[2].ff(t) / rbd.ff(t)) == fv_importance[2]
+    )
+    assert (
+        pytest.approx(rbd.components[3].ff(t) / rbd.ff(t)) == fv_importance[3]
+    )
+    assert (
+        pytest.approx(rbd.components[4].ff(t) / rbd.ff(t)) == fv_importance[4]
+    )
+    assert (
+        pytest.approx(rbd.components[2].ff(t) / rbd.ff(t)) == fv_importance[5]
+    )
+
+
+def test_fussel_vesely_p_rbd_repeated_component_series(
+    rbd_repeated_component_series: RBD,
+):
+    rbd = rbd_repeated_component_series
+    t = 2
+    fv_importance = rbd.fussel_vesely(t, fv_type="p")
+    expected_fv_importance = (
+        rbd.components[2].ff(t) * rbd.components[3].ff(t) / rbd.ff(t)
+    )
+    assert pytest.approx(expected_fv_importance) == fv_importance[2]
+    assert pytest.approx(expected_fv_importance) == fv_importance[3]
+    assert pytest.approx(expected_fv_importance) == fv_importance[4]

--- a/repyability/tests/test_rbd.py
+++ b/repyability/tests/test_rbd.py
@@ -185,13 +185,13 @@ def test_rbd_components(rbd1: RBD, rbd2: RBD):
     assert len(rbd2.components) == 8
 
 
-# Test all_path_sets()
-def test_rbd_all_path_sets(rbd1: RBD, rbd2: RBD):
-    assert list(rbd1.all_path_sets()) == [
+# Test get_all_path_sets()
+def test_rbd_get_all_path_sets(rbd1: RBD, rbd2: RBD):
+    assert list(rbd1.get_all_path_sets()) == [
         ["source", "pump1", "valve", "sink"],
         ["source", "pump2", "valve", "sink"],
     ]
-    assert list(rbd2.all_path_sets()) == [
+    assert list(rbd2.get_all_path_sets()) == [
         [1, 2, 3, 5, 6, 7, 8],
         [1, 2, 4, 7, 8],
     ]
@@ -211,6 +211,8 @@ def test_rbd_sf_series(rbd_series: RBD):
         == rbd_series.sf(t)[0]
     )
 
+
+# Test
 
 # Test get_min_cut_sets()
 

--- a/repyability/tests/test_rbd.py
+++ b/repyability/tests/test_rbd.py
@@ -594,7 +594,7 @@ def test_fussel_vesely_c_series(rbd_series: RBD):
     )
 
 
-def test_fussel_vesely_parallel(rbd_parallel: RBD):
+def test_fussel_vesely_c_parallel(rbd_parallel: RBD):
     t = 2
     fv_importance = rbd_parallel.fussel_vesely(t)
     fv_expected = (
@@ -608,7 +608,7 @@ def test_fussel_vesely_parallel(rbd_parallel: RBD):
     assert pytest.approx(fv_expected) == fv_importance[4]
 
 
-def test_fussel_vesely_rbd2(rbd2: RBD):
+def test_fussel_vesely_c_rbd2(rbd2: RBD):
     t = 2
     fv_importance = rbd2.fussel_vesely(t)
     assert (
@@ -650,7 +650,7 @@ def test_fussel_vesely_rbd2(rbd2: RBD):
     )
 
 
-def test_fussel_vesely_rbd3(rbd3: RBD):
+def test_fussel_vesely_c_rbd3(rbd3: RBD):
     t = 2
     fv_importance = rbd3.fussel_vesely(t)
     assert (
@@ -691,10 +691,12 @@ def test_fussel_vesely_rbd3(rbd3: RBD):
     )
     assert (
         pytest.approx(
-            rbd3.components[2].ff(t) * rbd3.components[4].ff(t)
-            + rbd3.components[1].ff(t)
-            * rbd3.components[4].ff(t)
-            * rbd3.components[5].ff(t)
+            (
+                rbd3.components[2].ff(t) * rbd3.components[4].ff(t)
+                + rbd3.components[1].ff(t)
+                * rbd3.components[4].ff(t)
+                * rbd3.components[5].ff(t)
+            )
             / rbd3.ff(t)
         )
         == fv_importance[4]
@@ -712,4 +714,66 @@ def test_fussel_vesely_rbd3(rbd3: RBD):
             / rbd3.ff(t)
         )
         == fv_importance[5]
+    )
+
+
+def test_fussel_vesely_c_repeated_component_parallel(
+    rbd_repeated_component_parallel: RBD,
+):
+    rbd = rbd_repeated_component_parallel
+    t = 2
+    fv_importance = rbd.fussel_vesely(t)
+    fv_expected = (
+        rbd.components[2].ff(t)
+        * rbd.components[3].ff(t)
+        * rbd.components[4].ff(t)
+        / rbd.ff(t)
+    )
+    assert pytest.approx(fv_expected) == fv_importance[2]
+    assert pytest.approx(fv_expected) == fv_importance[3]
+    assert pytest.approx(fv_expected) == fv_importance[4]
+    assert pytest.approx(fv_expected) == fv_importance[5]
+
+
+def test_fussel_vesely_c_rbd_repeated_component_series(
+    rbd_repeated_component_series: RBD,
+):
+    rbd = rbd_repeated_component_series
+    t = 2
+    fv_importance = rbd.fussel_vesely(t)
+    assert (
+        pytest.approx(rbd.components[2].ff(t) / rbd.ff(t)) == fv_importance[2]
+    )
+    assert (
+        pytest.approx(rbd.components[3].ff(t) / rbd.ff(t)) == fv_importance[3]
+    )
+    assert (
+        pytest.approx(rbd.components[2].ff(t) / rbd.ff(t)) == fv_importance[4]
+    )
+
+
+def test_fussel_vesely_c_rbd_repeated_component_composite(
+    rbd_repeated_component_composite: RBD,
+):
+    rbd = rbd_repeated_component_composite
+    t = 2
+    fv_importance = rbd.fussel_vesely(t)
+    assert (
+        pytest.approx(
+            (
+                rbd.components[2].ff(t)
+                + rbd.components[2].ff(t) * rbd.components[3].ff(t)
+            )
+            / rbd.ff(t)
+        )
+        == fv_importance[2]
+    )
+    assert (
+        pytest.approx(rbd.components[2].ff(t) / rbd.ff(t)) == fv_importance[3]
+    )
+    assert (
+        pytest.approx(
+            rbd.components[2].ff(t) * rbd.components[3].ff(t) / rbd.ff(t)
+        )
+        == fv_importance[4]
     )

--- a/repyability/tests/test_rbd.py
+++ b/repyability/tests/test_rbd.py
@@ -212,7 +212,40 @@ def test_rbd_sf_series(rbd_series: RBD):
     )
 
 
-# Test
+# Test get_min_path_sets()
+
+
+def test_rbd_get_min_path_sets_rbd_series(rbd_series: RBD):
+    assert {(1, 2, 3, 4, 5)} == rbd_series.get_min_path_sets()
+
+
+def test_rbd_get_min_path_sets_rbd_parallel(rbd_parallel: RBD):
+    assert {
+        (1, 2, 5),
+        (1, 3, 5),
+        (1, 4, 5),
+    } == rbd_parallel.get_min_path_sets()
+
+
+def test_rbd_get_min_path_sets_rbd1(rbd1: RBD):
+    assert {
+        ("source", "pump1", "valve", "sink"),
+        ("source", "pump2", "valve", "sink"),
+    } == rbd1.get_min_path_sets()
+
+
+def test_rbd_get_min_path_sets_rbd2(rbd2: RBD):
+    assert {(1, 2, 3, 5, 6, 7, 8), (1, 2, 4, 7, 8)} == rbd2.get_min_path_sets()
+
+
+def test_rbd_get_min_path_sets_rbd3(rbd3: RBD):
+    assert {
+        (0, 1, 2, 6),
+        (0, 1, 5, 4, 6),
+        (0, 3, 4, 6),
+        (0, 3, 5, 2, 6),
+    } == rbd3.get_min_path_sets()
+
 
 # Test get_min_cut_sets()
 

--- a/repyability/tests/test_rbd.py
+++ b/repyability/tests/test_rbd.py
@@ -549,27 +549,167 @@ def test_rbd_criticality_importance(rbd1: RBD):
     )
 
 
-# TODO: Test fussel_vessely
+# Test fussel_vesely() w/ cut-set method
 
 
-# TODO: Test importance calcs, need to fix survival function first though
-# def test_rbd_fussel_vessely_path_set(rbd1):
-#     # PS = Path Set
-#     # PS1 = [1, 2, 4, 5]
-#     # PS2 = [1, 3, 4, 5]
-#     # Q(PS1) = Q(PS2) = Q23 * Q4
-#     # Note Q2 = Q3 = Q23
+def test_fussel_vesely_c_rbd1(rbd1: RBD):
+    t = 2
+    fv_importance = rbd1.fussel_vesely(t)
+    assert (
+        pytest.approx(
+            rbd1.components["pump1"].ff(t)
+            * rbd1.components["pump2"].ff(t)
+            / rbd1.ff(t)
+        )
+        == fv_importance["pump1"]
+    )
+    assert (
+        pytest.approx(
+            rbd1.components["pump1"].ff(t)
+            * rbd1.components["pump2"].ff(t)
+            / rbd1.ff(t)
+        )
+        == fv_importance["pump2"]
+    )
+    assert (
+        pytest.approx(rbd1.components["valve"].ff(t) / rbd1.ff(t))
+        == fv_importance["valve"]
+    )
 
-#     Q_
 
-#     # Path set unreliability
-#     Q_PS = (1 - rbd1.components[2].sf(1)) * (1 - rbd1.components[4].sf(1))
+def test_fussel_vesely_c_series(rbd_series: RBD):
+    t = 2
+    fv_importance = rbd_series.fussel_vesely(t)
+    assert (
+        pytest.approx(rbd_series.components[2].ff(t) / rbd_series.ff(t))
+        == fv_importance[2]
+    )
+    assert (
+        pytest.approx(rbd_series.components[3].ff(t) / rbd_series.ff(t))
+        == fv_importance[3]
+    )
+    assert (
+        pytest.approx(rbd_series.components[4].ff(t) / rbd_series.ff(t))
+        == fv_importance[4]
+    )
 
-#     # System unreliability
-#     Q_sys =
 
-#     # Fussel-Vessely importance of components 2 and 3
-#     I_FV_23 = Q_PS / Q_sys
+def test_fussel_vesely_parallel(rbd_parallel: RBD):
+    t = 2
+    fv_importance = rbd_parallel.fussel_vesely(t)
+    fv_expected = (
+        rbd_parallel.components[2].ff(t)
+        * rbd_parallel.components[3].ff(t)
+        * rbd_parallel.components[4].ff(t)
+        / rbd_parallel.ff(t)
+    )
+    assert pytest.approx(fv_expected) == fv_importance[2]
+    assert pytest.approx(fv_expected) == fv_importance[3]
+    assert pytest.approx(fv_expected) == fv_importance[4]
 
-#     # Fussel-Vessely importance of comonent 4
-#     rbd1.fussel_vessely()
+
+def test_fussel_vesely_rbd2(rbd2: RBD):
+    t = 2
+    fv_importance = rbd2.fussel_vesely(t)
+    assert (
+        pytest.approx(rbd2.components[2].ff(t) / rbd2.ff(t))
+        == fv_importance[2]
+    )
+    assert (
+        pytest.approx(
+            rbd2.components[3].ff(t) * rbd2.components[4].ff(t) / rbd2.ff(t)
+        )
+        == fv_importance[3]
+    )
+    assert (
+        pytest.approx(
+            (
+                rbd2.components[4].ff(t) * rbd2.components[5].ff(t)
+                + rbd2.components[3].ff(t) * rbd2.components[4].ff(t)
+                + rbd2.components[4].ff(t) * rbd2.components[6].ff(t)
+            )
+            / rbd2.ff(t)
+        )
+        == fv_importance[4]
+    )
+    assert (
+        pytest.approx(
+            rbd2.components[4].ff(t) * rbd2.components[5].ff(t) / rbd2.ff(t)
+        )
+        == fv_importance[5]
+    )
+    assert (
+        pytest.approx(
+            rbd2.components[4].ff(t) * rbd2.components[6].ff(t) / rbd2.ff(t)
+        )
+        == fv_importance[6]
+    )
+    assert (
+        pytest.approx(rbd2.components[7].ff(t) / rbd2.ff(t))
+        == fv_importance[7]
+    )
+
+
+def test_fussel_vesely_rbd3(rbd3: RBD):
+    t = 2
+    fv_importance = rbd3.fussel_vesely(t)
+    assert (
+        pytest.approx(
+            (
+                rbd3.components[1].ff(t) * rbd3.components[3].ff(t)
+                + rbd3.components[1].ff(t)
+                * rbd3.components[4].ff(t)
+                * rbd3.components[5].ff(t)
+            )
+            / rbd3.ff(t)
+        )
+        == fv_importance[1]
+    )
+    assert (
+        pytest.approx(
+            (
+                rbd3.components[2].ff(t) * rbd3.components[4].ff(t)
+                + rbd3.components[2].ff(t)
+                * rbd3.components[3].ff(t)
+                * rbd3.components[5].ff(t)
+            )
+            / rbd3.ff(t)
+        )
+        == fv_importance[2]
+    )
+    assert (
+        pytest.approx(
+            (
+                rbd3.components[1].ff(t) * rbd3.components[3].ff(t)
+                + rbd3.components[2].ff(t)
+                * rbd3.components[3].ff(t)
+                * rbd3.components[5].ff(t)
+            )
+            / rbd3.ff(t)
+        )
+        == fv_importance[3]
+    )
+    assert (
+        pytest.approx(
+            rbd3.components[2].ff(t) * rbd3.components[4].ff(t)
+            + rbd3.components[1].ff(t)
+            * rbd3.components[4].ff(t)
+            * rbd3.components[5].ff(t)
+            / rbd3.ff(t)
+        )
+        == fv_importance[4]
+    )
+    assert (
+        pytest.approx(
+            (
+                rbd3.components[1].ff(t)
+                * rbd3.components[4].ff(t)
+                * rbd3.components[5].ff(t)
+                + rbd3.components[2].ff(t)
+                * rbd3.components[3].ff(t)
+                * rbd3.components[5].ff(t)
+            )
+            / rbd3.ff(t)
+        )
+        == fv_importance[5]
+    )


### PR DESCRIPTION
- Tests and implementation for fussel-vesely cut-set and path-set methods
- This included the minimum path-sets implementation (see `get_min_path_sets()`)

Please let me know @derrynknife what you think of the return types for `get_min_path_sets()` and `get_min_cut_sets()`. Mathematically they make the most sense, but unsure if it's the most pythonic and usable way to do it.