### PR TITLE
Added CI

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,6 +1,6 @@
 name: actions
 
-run-name: triggered by ${{ github.actor }}
+run-name: RePyability CI
 
 on: [push]
 
@@ -8,7 +8,7 @@ env:
   SRC: repyability # Source directory to run jobs on
 
 jobs:
-  build-test-lint-format:
+  repyability_ci:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -29,6 +29,10 @@ jobs:
       
       - name: flake8
         run: flake8 $SRC
+      
+      - name: mypy
+        # Ignore untyped libraries scipy, networkx, and surpyval
+        run: mypy --ignore-missing-imports $SRC
       
       - name: black
         run:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -26,7 +26,7 @@ jobs:
       - name: pytest and coverage
         run:
           coverage run -m pytest
-      
+          
       - name: Upload coverage html report artifact
         - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -8,7 +8,7 @@ env:
   SRC: repyability # Source directory to run jobs on
 
 jobs:
-  build:
+  build-test-lint-format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set-up Python 3.x
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.10'
       
       - name: Install dependencies
         run: |

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -23,10 +23,15 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       
-      - name: pytest and coverage
+      - name: pytest
         run:
           coverage run -m pytest
       
+      - name: coverage
+        run: |
+          coverage report
+          coverage html
+
       - name: Upload coverage html report artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -26,9 +26,9 @@ jobs:
       - name: pytest and coverage
         run:
           coverage run -m pytest
-          
+      
       - name: Upload coverage html report artifact
-        - uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3
         with:
           name: coverage-html-report
           path: htmlcov/

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -23,9 +23,15 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       
-      - name: pytest
+      - name: pytest and coverage
         run:
-          python -m pytest
+          coverage run -m pytest
+      
+      - name: Upload coverage html report artifact
+        - uses: actions/upload-artifact@v3
+        with:
+          name: coverage-html-report
+          path: htmlcov/
       
       - name: flake8
         run: flake8 $SRC

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,0 +1,35 @@
+name: actions
+
+run-name: triggered by ${{ github.actor }}
+
+on: [push]
+
+env:
+  SRC: repyability # Source directory to run jobs on
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set-up Python 3.x
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      
+      - name: pytest
+        run:
+          python -m pytest
+      
+      - name: flake8
+        run: flake8 $SRC
+      
+      - name: black
+        run:
+          black $SRC

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,10 +16,6 @@ profile = "black"
 [mypy]
 plugins = "numpy.typing.mypy_plugin"
 
-# Ignore untyped libraries scipy, networkx, and surpyval
-[tool.mypy]
-ignore_missing_imports = true
-
 # Coverage
 [tool.coverage.run]
 source = ["repyability"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,10 @@ profile = "black"
 [mypy]
 plugins = "numpy.typing.mypy_plugin"
 
+# Ignore untyped libraries scipy, networkx, and surpyval
+[tool.mypy]
+ignore_missing_imports = true
+
 # Coverage
 [tool.coverage.run]
 source = ["repyability"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+black
 coverage
 flake8
 networkx

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 coverage
+flake8
 networkx
 numpy
 pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 black
 coverage
 flake8
+mypy
 networkx
 numpy
 pre-commit


### PR DESCRIPTION
Added Github-hosted actions (CI) with the following steps:
- Pytest (under coverage's watch)
- Print coverage report and make coverage html report
- Upload coverage html report as an artifact
- flake8
- mypy (ignoring missing imports for untyped libraries scipy, networkx, and survival
- black (check it's formatted with black)

Ultimately all these things apart from the testing should be already satisfied if using the pre-commit workflow.