### PR TITLE
Improve requirements.txt

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r requirements_dev.txt
       
       - name: pytest
         run:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,11 +2,6 @@
 # See https://pre-commit.com/hooks.html for more hooks
 
 repos:
-# Organise requirements.txt 
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 'v4.3.0'
-    hooks:
-    -   id: requirements-txt-fixer
 
 # Organise imports
 -   repo: https://github.com/PyCQA/isort

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,7 @@
-black
-coverage
-dd
-flake8
-mypy
-networkx
-numpy
-pre-commit
-pytest
-scipy
-surpyval
-tqdm
+# Production requirements
+# For development, use requirements_dev.txt instead
+dd==0.5.7
+networkx==3.0
+numpy==1.23.5
+surpyval==0.10.10
+tqdm==4.64.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,10 @@
+# Include production requirements
+-r requirements.txt
+
+# Dev requirements
+black
+flake8
+mypy
+pytest
+coverage
+pre-commit


### PR DESCRIPTION
Separated production and development requirements into `requirements.txt` and `requirements_dev.txt` respectively. Also locked (i.e. gave specific version numbers to) all production requirements.

This will help for when repyability is deployed into production on cloud instances etc. because it won't default to installing all the hefty mypy/flake8/etc.

Therefore when developing, instead of using `pip install -r requirements.txt`, just use `pip install -r requirements_dev.txt` (this file includes all requirements from `requirements.txt`).