### PR TITLE
Fix master CI: drop Python 3.10 support and clear mypy errors

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ work is tracked as issues in the GitHub repository).
   package (`from repyability import NonRepairableRBD, StandbyModel, ...`) and
   listed in `__all__`. `repyability.__version__` is available.
 - **`NonRepairableRBD.is_fixed`** property.
-- CI now runs a lint/type gate and a test matrix (Python 3.10–3.12) with a
+- CI now runs a lint/type gate and a test matrix (Python 3.11–3.12) with a
   coverage `fail_under` gate; a release workflow publishes to PyPI via trusted
   publishing.
 - `CHANGELOG.md`, `CONTRIBUTING.md`, and issue/PR templates.
@@ -125,7 +125,9 @@ work is tracked as issues in the GitHub repository).
   instead of a plain `dict`. It is a `collections.abc.Mapping` (not a `dict`
   subclass), so dict-style access is preserved but `isinstance(result, dict)`
   is now False (use `isinstance(result, Mapping)`).
-- Requires Python >= 3.10.
+- Requires Python >= 3.11 (raised from 3.10: `surpyval` >= 0.11.1, the core
+  dependency, itself requires Python >= 3.11, so the declared 3.10 support could
+  not actually be installed).
 
 ### Fixed
 - Removed a stray debug `print()` in `RBD.improvement_allocation`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Reliability engineering tools for Python"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 authors = [{ name = "derrynknife", email = "derrynknife@gmail.com" }]
 keywords = [
     "reliability",
@@ -26,7 +26,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering",

--- a/repyability/rbd/non_repairable_rbd.py
+++ b/repyability/rbd/non_repairable_rbd.py
@@ -4,7 +4,16 @@ import warnings
 from copy import copy
 from dataclasses import dataclass, field
 from queue import PriorityQueue
-from typing import Any, Collection, Dict, Hashable, Iterable, Optional, Union
+from typing import (
+    Any,
+    Collection,
+    Dict,
+    Hashable,
+    Iterable,
+    Optional,
+    Union,
+    cast,
+)
 
 import networkx as nx
 import numpy as np
@@ -455,7 +464,7 @@ class NonRepairableRBD(RBD):
     ) -> Dict[Any, Union[float, np.ndarray]]:
         """Returns each node's reliability at time/s x (a dict keyed by node
         name). Floats for scalar ``x``, arrays for array ``x``."""
-        node_sf: Dict[Any, np.ndarray] = {}
+        node_sf: Dict[Any, Union[float, np.ndarray]] = {}
         for node_name, node in self.reliabilities.items():
             node_sf[node_name] = node.sf(x)
         return node_sf
@@ -466,7 +475,7 @@ class NonRepairableRBD(RBD):
     ) -> Dict[Any, Union[float, np.ndarray]]:
         """Returns each node's unreliability at time/s x (a dict keyed by node
         name). Floats for scalar ``x``, arrays for array ``x``."""
-        node_ff: Dict[Any, np.ndarray] = {}
+        node_ff: Dict[Any, Union[float, np.ndarray]] = {}
         for node_name, node in self.reliabilities.items():
             node_ff[node_name] = node.ff(x)
 
@@ -790,7 +799,10 @@ class NonRepairableRBD(RBD):
         node_probabilities = self._probabilities_with_overrides(
             self.node_sf(x), working_nodes, broken_nodes
         )
-        return super()._birnbaum_importance(node_probabilities)
+        return cast(
+            Dict[Any, Union[float, np.ndarray]],
+            super()._birnbaum_importance(node_probabilities),
+        )
 
     @check_x
     def improvement_potential(
@@ -819,7 +831,10 @@ class NonRepairableRBD(RBD):
         node_probabilities = self._probabilities_with_overrides(
             self.node_sf(x), working_nodes, broken_nodes
         )
-        return super()._improvement_potential(node_probabilities)
+        return cast(
+            Dict[Any, Union[float, np.ndarray]],
+            super()._improvement_potential(node_probabilities),
+        )
 
     @check_x
     def risk_achievement_worth(
@@ -850,7 +865,10 @@ class NonRepairableRBD(RBD):
         node_probabilities = self._probabilities_with_overrides(
             self.node_sf(x), working_nodes, broken_nodes
         )
-        return super()._risk_achievement_worth(node_probabilities)
+        return cast(
+            Dict[Any, Union[float, np.ndarray]],
+            super()._risk_achievement_worth(node_probabilities),
+        )
 
     @check_x
     def risk_reduction_worth(
@@ -881,7 +899,10 @@ class NonRepairableRBD(RBD):
         node_probabilities = self._probabilities_with_overrides(
             self.node_sf(x), working_nodes, broken_nodes
         )
-        return super()._risk_reduction_worth(node_probabilities)
+        return cast(
+            Dict[Any, Union[float, np.ndarray]],
+            super()._risk_reduction_worth(node_probabilities),
+        )
 
     @check_x
     def criticality_importance(
@@ -910,7 +931,10 @@ class NonRepairableRBD(RBD):
         node_probabilities = self._probabilities_with_overrides(
             self.node_sf(x), working_nodes, broken_nodes
         )
-        return super()._criticality_importance(node_probabilities)
+        return cast(
+            Dict[Any, Union[float, np.ndarray]],
+            super()._criticality_importance(node_probabilities),
+        )
 
     @check_x
     def fussell_vesely(
@@ -963,7 +987,10 @@ class NonRepairableRBD(RBD):
         rel_dict = self._probabilities_with_overrides(
             rel_dict, working_nodes, broken_nodes
         )
-        return super()._fussell_vesely(rel_dict, fv_type)
+        return cast(
+            Dict[Any, Union[float, np.ndarray]],
+            super()._fussell_vesely(rel_dict, fv_type),
+        )
 
     def fussel_vesely(
         self, x: Optional[ArrayLike] = None, fv_type: str = "c"

--- a/repyability/rbd/numerical_convolution.py
+++ b/repyability/rbd/numerical_convolution.py
@@ -10,6 +10,8 @@ quickly -- as a robust alternative to estimating it from Monte-Carlo samples
 with a Kaplan-Meier fit.
 """
 
+from typing import cast
+
 import numpy as np
 from scipy.integrate import cumulative_trapezoid, trapezoid
 from scipy.signal import fftconvolve
@@ -53,7 +55,7 @@ def switch_success_probs(switching_probability, n) -> list:
     if n <= 1:
         return []
     if np.isscalar(switching_probability):
-        probs = [float(switching_probability)] * (n - 1)
+        probs = [float(cast(float, switching_probability))] * (n - 1)
     else:
         probs = [float(p) for p in switching_probability]
         if len(probs) != n - 1:
@@ -70,7 +72,7 @@ def switch_success_probs(switching_probability, n) -> list:
 def is_perfect_switching(switching_probability) -> bool:
     """True if every switch succeeds with probability 1."""
     if np.isscalar(switching_probability):
-        return float(switching_probability) == 1.0
+        return float(cast(float, switching_probability)) == 1.0
     return all(float(p) == 1.0 for p in switching_probability)
 
 

--- a/repyability/rbd/rbd.py
+++ b/repyability/rbd/rbd.py
@@ -206,6 +206,11 @@ def minimal_cut_sets_from_path_sets(
 
 
 class RBD:
+    # Constructor inputs, captured verbatim by each subclass's ``__init__`` so
+    # the RBD can be re-created (see ``serialisation``); declared here so the
+    # attribute is visible on the base type.
+    _init_args: dict
+
     def __init__(
         self,
         edges: Iterable[tuple[Hashable, Hashable]],

--- a/repyability/rbd/repairable_rbd.py
+++ b/repyability/rbd/repairable_rbd.py
@@ -271,7 +271,7 @@ class RepairableRBD(RBD):
         self.t_simulation = t_simulation
         self.component_status = component_status
 
-    def mean_unavailability(self, *args, **kwargs) -> np.float64:
+    def mean_unavailability(self, *args, **kwargs) -> float:
         """Returns the system long run UNavailability
 
         Parameters
@@ -929,7 +929,7 @@ class RepairableRBD(RBD):
             super()._fussell_vesely(node_probabilities, fv_type)
         )
 
-    def fussel_vesely(self, fv_type: str = "c") -> dict[Any, np.ndarray]:
+    def fussel_vesely(self, fv_type: str = "c") -> dict[Any, float]:
         """Deprecated alias for :meth:`fussell_vesely` (corrected spelling)."""
         warnings.warn(
             "fussel_vesely() is deprecated; use fussell_vesely() "


### PR DESCRIPTION
## Summary

Two CI jobs were failing on `master` — both pre-existing and unrelated to the roadmap decommission (#46). This gets `master` green (and unblocks the 0.5.0 release, #32).

**`test (Python 3.10)`** — `surpyval` >= 0.11.1 (the core dependency) now declares `Requires-Python >=3.11`, so pip could not resolve `surpyval>=0.11.1,<0.12` on 3.10 and the job failed at the install step. The declared 3.10 support was therefore already un-installable. Fix: raise `requires-python` to `>=3.11`, drop 3.10 from the test matrix and the classifiers, and note it in the changelog.

**`lint (mypy)`** — 13 errors, all fixed with **no change to runtime behaviour**:
- Declare `_init_args` on the base `RBD` class (each subclass `__init__` sets it; `serialisation` reads it off the base type).
- `numerical_convolution`: `cast` the `np.isscalar`-guarded value before `float()` — numpy 2.x types `np.isscalar` as a `TypeGuard` that widens to `generic | complex | str | bytes | memoryview`, which `float()` rejects.
- `non_repairable_rbd`: the per-node and importance methods yield float-or-array via the `@check_x` squeeze; annotate the local dicts and `cast` the base class's `ndarray`-valued results to the declared union (`dict` is invariant in its value type — this is mypy's own suggested class of fix).
- `repairable_rbd`: `mean_unavailability` returns a plain `float`, not `np.float64`; the deprecated `fussel_vesely` alias returns `dict[Any, float]` like the method it forwards to.

## Type of change

- [x] Bug fix (CI/tooling)
- [ ] New feature
- [ ] Documentation
- [x] Refactor / tooling
- [x] Breaking change — raises the minimum Python to 3.11 (forced by `surpyval`; 3.10 could not install anyway)

## Checklist

- [ ] Tests added/updated — N/A, no behaviour change (existing suite exercises these paths)
- [x] `black`, `isort`, `flake8`, and `mypy` pass
- [x] `coverage run -m pytest` passes and stays above the coverage gate (287 passed, 90%)
- [x] `CHANGELOG.md` updated (Python-version line + CI matrix line)
- [ ] Any Monte-Carlo tests are seeded (deterministic) — N/A

## Notes for reviewers

Verified locally on Python 3.11: `mypy` clean, `black`/`isort`/`flake8` pass, 287 tests pass, coverage 90%. The type fixes are annotations/casts only; the sole behavioural change is dropping Python 3.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUGaeQXKxjjiQ1ULT1ApXS

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUGaeQXKxjjiQ1ULT1ApXS)_