### PR TITLE
Build out the maintenance-policy layer: Repairable rebuilt, NonRepairable polished

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,23 @@ work is tracked as issues in the GitHub repository).
   exponential systems) within Monte-Carlo sampling error, and the
   finite-window censoring bias of the simulation MUT/MDT estimates is
   documented.
+- **Component maintenance-policy layer.** The vestigial `Repairable` class
+  is now a real minimal-repair ("as bad as old") economics tool: it takes a
+  surpyval recurrence model (anything exposing `cif`, e.g. Crow-AMSAA,
+  Duane) and finds the optimal overhaul interval minimising
+  `(cr*Lambda(t) + co)/t` (the Barlow-Hunter policy), returning `inf` when
+  the unit does not wear out (HPP-like, `beta <= 1`) — validated against
+  the power-law closed form. New typed result `MaintenancePolicy`
+  (`interval`, `cost_rate`), returned by
+  `Repairable.optimal_overhaul_policy()` and the new
+  `NonRepairable.optimal_replacement_policy()`.
+  `NonRepairable.find_optimal_replacement()` now returns `inf` for an
+  exponential lifetime (memoryless — preventive replacement never pays),
+  matching the existing Weibull shape <= 1 behaviour. A user-guide section
+  explains renewal ("as good as new", `NonRepairable` — also the component
+  representation inside `RepairableRBD`) vs minimal repair (`Repairable` —
+  standalone; not a valid RBD node model, since RBD repairs are assumed to
+  renew).
 
 ### Changed
 - **API standardised across `RBD`/`NonRepairableRBD`/`RepairableRBD`**
@@ -156,6 +173,12 @@ work is tracked as issues in the GitHub repository).
   uptime + downtime now correctly sums to `N * t_simulation`. (`sf`/`ff` and
   the derived `reliability`/`unreliability`/`cs` paths were audited for the
   working/broken overrides and found correct; regression tests added.)
+- `Repairable.find_optimal_overhaul_interval()` returned a raw
+  `scipy.optimize` result object instead of the interval, performed an
+  unbounded search from an arbitrary starting point, and the class
+  docstring described the wrong class ("stores the non-repairable
+  information"). All fixed in the rebuild; the previously commented-out
+  `test_repairable.py` is resurrected with closed-form validation.
 
 ### Removed
 - Dead/unused `repyability/rbd/rbd_args_check.py` module and the never-

--- a/docs/api.md
+++ b/docs/api.md
@@ -42,3 +42,5 @@ the top-level `repyability` package).
 ::: repyability.FailureCriticalityIndex
 
 ::: repyability.RestorationCriticalityIndex
+
+::: repyability.MaintenancePolicy

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -200,6 +200,66 @@ result.criticalities.failure_criticality_index.per_system_failure
 
 See [`Criticalities`][repyability.Criticalities] for what each measure means.
 
+## Maintenance policies: replacement vs overhaul
+
+Two component-level classes price preventive maintenance. They sit at the
+two ends of the repair-effectiveness spectrum:
+
+- [`NonRepairable`][repyability.NonRepairable] — the unit is **replaced** on
+  failure ("as good as new"): every cycle is a statistical renewal. This is
+  also the component model `RepairableRBD` uses internally, because RBD
+  repairs are assumed to restore a component to as-new.
+- [`Repairable`][repyability.Repairable] — the unit is patched by **minimal
+  repair** ("as bad as old"): fixes restore function but not age, so
+  failures arrive ever faster, following a recurrent-event model (its
+  cumulative intensity `cif`, e.g. surpyval's Crow-AMSAA). Because that
+  violates the renewal assumption, `Repairable` is a standalone tool — it
+  is **not** a valid RBD node model.
+
+### Age replacement (`NonRepairable`)
+
+Replace preventively at age `t` (planned, cost `cp`) or on failure
+(unplanned, cost `cu > cp`); minimise the long-run cost rate:
+
+```python
+import surpyval as surv
+from repyability import NonRepairable
+
+comp = NonRepairable(surv.Weibull.from_params([1000, 2.5]))
+comp.set_costs_planned_and_unplanned(1, 5)
+
+comp.find_optimal_replacement()       # optimal replacement age (float)
+policy = comp.optimal_replacement_policy()
+policy.interval, policy.cost_rate     # typed MaintenancePolicy result
+```
+
+If the lifetime shows no aging (an exponential, or a Weibull with shape
+&le; 1), preventive replacement never pays: the interval is `inf` and the
+policy cost rate is the run-to-failure rate `cu / MTTF`.
+
+### Overhaul under minimal repair (`Repairable`)
+
+Minimal repairs cost `cr` each; an overhaul costs `co > cr` and renews the
+unit. The optimal overhaul interval minimises
+`(cr * Lambda(t) + co) / t`, where `Lambda` is the cumulative intensity —
+the classic Barlow-Hunter policy:
+
+```python
+import surpyval as surv
+from repyability import Repairable
+
+unit = Repairable(surv.CrowAMSAA.from_params([1500, 1.5]))
+unit.set_repair_and_overhaul_costs(100, 10_000)
+
+unit.find_optimal_overhaul_interval()   # inf if the unit never wears out
+policy = unit.optimal_overhaul_policy()
+policy.interval, policy.cost_rate
+```
+
+A finite optimum requires wear-out (Crow-AMSAA `beta > 1`). For HPP-like
+behaviour (`beta <= 1`) repairs never become more frequent, overhauls never
+pay, and the interval is `inf` with the cost rate of repairs alone.
+
 ## Saving and loading
 
 An RBD round-trips to a plain, JSON-friendly structure, so it can be saved,

--- a/repyability/__init__.py
+++ b/repyability/__init__.py
@@ -7,6 +7,7 @@ directly from the top-level package, e.g.::
 """
 
 from repyability._version import __version__
+from repyability.maintenance import MaintenancePolicy
 from repyability.non_repairable import NonRepairable
 from repyability.rbd.helper_classes import (
     PerfectReliability,
@@ -50,4 +51,5 @@ __all__ = [
     "UpDownImportance",
     "FailureCriticalityIndex",
     "RestorationCriticalityIndex",
+    "MaintenancePolicy",
 ]

--- a/repyability/maintenance.py
+++ b/repyability/maintenance.py
@@ -1,0 +1,28 @@
+"""Shared result types for component maintenance-policy optimisations."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class MaintenancePolicy:
+    """An optimal preventive-maintenance policy for a single component.
+
+    Returned by ``NonRepairable.optimal_replacement_policy()`` (age
+    replacement) and ``Repairable.optimal_overhaul_policy()`` (overhaul
+    under minimal repair).
+
+    Attributes
+    ----------
+    interval : float
+        The optimal preventive interval: the replacement age for an
+        age-replacement policy, or the overhaul interval for a
+        minimal-repair component. ``inf`` when preventive action never
+        pays (run to failure / never overhaul).
+    cost_rate : float
+        The long-run cost per unit time under the policy. When
+        ``interval`` is ``inf`` this is the limiting cost rate of running
+        without preventive action.
+    """
+
+    interval: float
+    cost_rate: float

--- a/repyability/non_repairable.py
+++ b/repyability/non_repairable.py
@@ -4,7 +4,12 @@ from scipy.interpolate import interp1d
 from scipy.optimize import minimize
 from surpyval import ExactEventTime, NonParametric, Parametric
 
-from repyability.rbd._model_utils import distribution_name, model_mean
+from repyability.maintenance import MaintenancePolicy
+from repyability.rbd._model_utils import (
+    distribution_name,
+    is_exponential,
+    model_mean,
+)
 from repyability.rbd.standby_node import StandbyModel
 
 FAILURE = 1
@@ -12,8 +17,24 @@ REPLACE = 0
 
 
 class NonRepairable:
-    """
-    Class to store the non-repairable information
+    """A component renewed by replacement ("as good as new").
+
+    Pairs a lifetime (reliability) model with a time-to-replace model for
+    a unit that cannot be repaired in place: every failure or planned
+    replacement fits a new unit, so each cycle is a statistical renewal.
+
+    It plays two roles:
+
+    - Standalone, it prices the classic *age-replacement* policy — replace
+      preventively at age ``t`` (planned, cost ``cp``) or on failure
+      (unplanned, cost ``cu > cp``) — via ``find_optimal_replacement()``
+      and ``optimal_replacement_policy()``.
+    - Inside ``RepairableRBD``, it is the per-component representation
+      used by the availability engine (components are "repaired" by as-new
+      replacement, which is exactly the renewal this class models).
+
+    Contrast with ``Repairable``, which models *minimal repair* ("as bad
+    as old") and the overhaul-interval policy.
     """
 
     def __init__(
@@ -40,7 +61,15 @@ class NonRepairable:
 
         self.reliability = reliability
         self.time_to_replace = time_to_replace
-        self.cost_rate = np.vectorize(self._cost_rate)
+        self.cost_rate = np.vectorize(
+            self._cost_rate,
+            doc=(
+                "Long-run cost per unit time of an age-replacement policy "
+                "with replacement age t:\n"
+                "(cp * R(t) + cu * F(t)) / integral_0^t R(u) du.\n"
+                "Vectorised over t."
+            ),
+        )
         self.__next_event_type = FAILURE
 
     def set_costs_planned_and_unplanned(self, cp, cu):
@@ -110,6 +139,14 @@ class NonRepairable:
 
     def find_optimal_replacement(self, options=None):
         if self.model_parameterization == "parametric":
+            if is_exponential(self.reliability) and not (
+                getattr(self.reliability, "offset", False)
+                or getattr(self.reliability, "zi", False)
+                or getattr(self.reliability, "lfp", False)
+            ):
+                # Memoryless lifetime: an old unit is statistically as good
+                # as a new one, so preventive replacement never pays.
+                return np.inf
             if distribution_name(self.reliability) == "Weibull":
                 if self.reliability.offset:
                     pass
@@ -155,6 +192,28 @@ class NonRepairable:
             optimal_idx = np.argmin(costs)
             optimal = x_search[optimal_idx]
         return optimal
+
+    def optimal_replacement_policy(self) -> MaintenancePolicy:
+        """The optimal age-replacement policy as a typed result.
+
+        Returns a ``MaintenancePolicy`` whose ``interval`` is the
+        cost-optimal replacement age and whose ``cost_rate`` is the
+        long-run cost per unit time under it. When preventive replacement
+        never pays (no aging — e.g. an exponential lifetime, or a Weibull
+        with shape <= 1) the interval is ``inf`` and the cost rate is the
+        run-to-failure rate ``cu / MTTF``.
+        """
+        if not hasattr(self, "cp"):
+            raise ValueError(
+                "costs not set: call set_costs_planned_and_unplanned"
+                "(cp, cu) first"
+            )
+        interval = self.find_optimal_replacement()
+        if np.isinf(interval):
+            rate = self.cu / model_mean(self.reliability)
+        else:
+            rate = float(self._cost_rate(interval))
+        return MaintenancePolicy(interval=float(interval), cost_rate=rate)
 
     def reset(self):
         self.__next_event_type = FAILURE

--- a/repyability/repairable.py
+++ b/repyability/repairable.py
@@ -1,15 +1,70 @@
-from scipy.optimize import minimize
+"""Minimal-repair ("as bad as old") component economics.
+
+A unit restored by *minimal repair* keeps its accumulated age through every
+fix: repairs return it to service but do not rejuvenate it, so failures
+recur with rising frequency. That failure history is a recurrent-event
+process with cumulative intensity ``Lambda(t)`` — the expected number of
+failures by age ``t`` — available from a surpyval recurrence model as
+``model.cif(t)`` (e.g. Crow-AMSAA / NHPP, Duane, HPP).
+
+``Repairable`` prices the classic trade-off for such a unit: each minimal
+repair costs ``cr``, while an *overhaul* costs ``co`` (> ``cr``) and renews
+the unit to as-new. Overhauling every ``t`` time units makes each overhaul
+cycle a renewal cycle costing ``cr * Lambda(t) + co``, so the long-run cost
+rate is::
+
+    g(t) = (cr * Lambda(t) + co) / t
+
+Minimising ``g`` gives the optimal overhaul interval (the Barlow-Hunter
+policy). A finite optimum exists only for wear-out models (``Lambda``
+growing super-linearly, e.g. Crow-AMSAA with ``beta > 1``); otherwise
+repairs never become frequent enough for overhauls to pay and the optimal
+interval is infinite.
+
+Contrast with ``NonRepairable``, which models renewal *by replacement*
+("as good as new") and the age-replacement policy. RBD components are
+assumed to renew on repair, so a minimal-repair unit is not a valid RBD
+node model — ``Repairable`` is a standalone component-level tool.
+"""
+
+from typing import Union
+
+import numpy as np
+from scipy.optimize import minimize_scalar
+
+from repyability.maintenance import MaintenancePolicy
 
 
 class Repairable:
-    """
-    Class to store the non-repairable information
+    """Minimal-repair component with an optimal-overhaul-interval policy.
+
+    Parameters
+    ----------
+    model : object
+        A recurrent-event model exposing ``cif(t)``, the cumulative
+        intensity (expected number of failures by age ``t``) — e.g. a
+        surpyval recurrence model (``CrowAMSAA``, ``Duane``, ``HPP``),
+        fitted or built ``from_params``.
     """
 
-    def __init__(self, distribution):
-        self.dist = distribution
+    def __init__(self, model):
+        if not hasattr(model, "cif"):
+            raise ValueError(
+                "model must expose cif() (a cumulative intensity "
+                "function), e.g. a surpyval recurrence model such as "
+                "CrowAMSAA"
+            )
+        self.model = model
 
-    def set_repair_and_overhaul_costs(self, cr, co):
+    def set_repair_and_overhaul_costs(self, cr: float, co: float) -> None:
+        """Set the minimal-repair cost ``cr`` and overhaul cost ``co``.
+
+        Requires ``0 < cr < co``: an overhaul (a full renewal) must cost
+        more than a minimal repair, otherwise one would simply overhaul at
+        every failure.
+        """
+        if cr <= 0:
+            raise ValueError("repair cost, cr, must be positive.")
         if cr >= co:
             raise ValueError(
                 "repair cost, cr, must be less than overhaul cost, co."
@@ -17,12 +72,119 @@ class Repairable:
         self.cr = cr
         self.co = co
 
-    def cost(self, t):
-        return self.cr * self.dist.cif(t) + self.co
+    def _require_costs(self) -> None:
+        if not hasattr(self, "cr"):
+            raise ValueError(
+                "costs not set: call set_repair_and_overhaul_costs(cr, co) "
+                "first"
+            )
 
-    def cost_rate(self, t):
-        return self.cost(t) / t
+    def _cif_scalar(self, t: float) -> float:
+        return float(np.asarray(self.model.cif(t), dtype=float).item())
 
-    def find_optimal_overhaul_interval(self):
+    def _g(self, t: float) -> float:
+        """Cost rate at a scalar ``t > 0`` (float in, float out)."""
+        return (self.cr * self._cif_scalar(t) + self.co) / t
 
-        return minimize(self.cost_rate, 1.0)
+    def cost(self, t) -> Union[float, np.ndarray]:
+        """Expected cost of one overhaul cycle of length ``t``:
+        ``cr * Lambda(t) + co``.
+
+        Scalar ``t`` returns a float; array ``t`` returns an array.
+        """
+        self._require_costs()
+        scalar_in = np.ndim(t) == 0
+        tt = np.atleast_1d(np.asarray(t, dtype=float))
+        lam = np.asarray(self.model.cif(tt), dtype=float)
+        out = self.cr * lam + self.co
+        return out.item() if scalar_in else out
+
+    def cost_rate(self, t) -> Union[float, np.ndarray]:
+        """Long-run cost per unit time when overhauling every ``t``:
+        ``(cr * Lambda(t) + co) / t``.
+
+        Scalar ``t`` returns a float; array ``t`` returns an array.
+        """
+        self._require_costs()
+        scalar_in = np.ndim(t) == 0
+        tt = np.atleast_1d(np.asarray(t, dtype=float))
+        lam = np.asarray(self.model.cif(tt), dtype=float)
+        with np.errstate(divide="ignore"):
+            out = (self.cr * lam + self.co) / tt
+        return out.item() if scalar_in else out
+
+    def _optimise(self) -> tuple[float, float]:
+        """Return ``(optimal interval, cost rate at it)``; the interval is
+        ``inf`` (with the limiting repair-only cost rate) when overhauls
+        never pay."""
+        self._require_costs()
+
+        # At a finite optimum the cumulative repair spend is comparable to
+        # the overhaul cost (for a power law, Lambda(t*) = co/(cr*(b-1))),
+        # so first bracket the age where Lambda(t) reaches co/cr and centre
+        # the search grid on that scale.
+        target = self.co / self.cr
+        t_scale = 1.0
+        if self._cif_scalar(t_scale) < target:
+            for _ in range(300):
+                t_scale *= 2.0
+                if self._cif_scalar(t_scale) >= target:
+                    break
+        else:
+            for _ in range(300):
+                if self._cif_scalar(t_scale / 2.0) < target:
+                    break
+                t_scale /= 2.0
+
+        for _ in range(6):
+            grid = t_scale * np.logspace(-4.0, 4.0, 1601)
+            g = np.asarray(self.cost_rate(grid))
+            i = int(np.argmin(g))
+            if i == len(grid) - 1:
+                # Minimum at the right edge: overhauling later keeps
+                # getting cheaper. If Lambda is not growing super-linearly
+                # out here, it never stops getting cheaper (no wear-out) —
+                # never overhaul.
+                big_t = float(grid[-1])
+                lam_t = self._cif_scalar(big_t)
+                lam_2t = self._cif_scalar(2.0 * big_t)
+                if lam_t <= 0.0 or (
+                    np.log(lam_2t / lam_t) / np.log(2.0) <= 1.0 + 1e-9
+                ):
+                    return float(np.inf), self._g(big_t)
+                t_scale *= 1e4  # genuine wear-out; optimum is further out
+                continue
+            if i == 0:
+                t_scale *= 1e-4
+                continue
+            res = minimize_scalar(
+                self._g,
+                bounds=(float(grid[i - 1]), float(grid[i + 1])),
+                method="bounded",
+            )
+            t_star = float(res.x)
+            return t_star, self._g(t_star)
+        # Search saturated (pathological model): best point found.
+        t_star = float(grid[i])
+        return t_star, self._g(t_star)
+
+    def find_optimal_overhaul_interval(self) -> float:
+        """The overhaul interval minimising the long-run cost rate.
+
+        Returns ``inf`` when overhauls never pay: the model does not wear
+        out (``Lambda(t)`` grows at most linearly — e.g. HPP, or Crow-AMSAA
+        with ``beta <= 1``), so the cost rate keeps falling as the
+        interval grows.
+        """
+        return self._optimise()[0]
+
+    def optimal_overhaul_policy(self) -> MaintenancePolicy:
+        """The optimal overhaul policy as a typed result.
+
+        Returns a ``MaintenancePolicy`` carrying the optimal interval and
+        the long-run cost rate under it. When the interval is ``inf``
+        (never overhaul), the cost rate is the limiting rate of minimal
+        repairs alone.
+        """
+        interval, rate = self._optimise()
+        return MaintenancePolicy(interval=interval, cost_rate=rate)

--- a/repyability/tests/test_non_repairable.py
+++ b/repyability/tests/test_non_repairable.py
@@ -136,3 +136,38 @@ def test_cost_rates():
     assert pytest.approx(nr_model._log_cost_rate(1000)) == np.log(
         nr_model.cost_rate(1000)
     )
+
+
+def test_exponential_never_replaced():
+    # Memoryless lifetime: an old unit is statistically as good as new,
+    # so preventive replacement can never pay.
+    from surpyval import Exponential
+
+    nr_model = NonRepairable(Exponential.from_params([0.001]))
+    nr_model.set_costs_planned_and_unplanned(1, 5)
+    assert nr_model.find_optimal_replacement() == np.inf
+
+    policy = nr_model.optimal_replacement_policy()
+    assert policy.interval == np.inf
+    # Run-to-failure cost rate: cu / MTTF = 5 / 1000.
+    assert policy.cost_rate == pytest.approx(5 * 0.001)
+
+
+def test_optimal_replacement_policy():
+    surv_model = Weibull.from_params((1000, 2.5))
+    nr_model = NonRepairable(surv_model)
+    nr_model.set_costs_planned_and_unplanned(1, 5)
+
+    policy = nr_model.optimal_replacement_policy()
+    assert policy.interval == pytest.approx(
+        nr_model.find_optimal_replacement()
+    )
+    assert policy.cost_rate == pytest.approx(
+        float(nr_model.cost_rate(policy.interval))
+    )
+
+
+def test_policy_requires_costs():
+    nr_model = NonRepairable(Weibull.from_params((1000, 2.5)))
+    with pytest.raises(ValueError, match="costs not set"):
+        nr_model.optimal_replacement_policy()

--- a/repyability/tests/test_repairable.py
+++ b/repyability/tests/test_repairable.py
@@ -1,14 +1,134 @@
+"""Tests for Repairable: minimal-repair ("as bad as old") components and
+the optimal-overhaul-interval (Barlow-Hunter) policy.
+
+For a power-law cumulative intensity Lambda(t) = (t/alpha)^beta (surpyval
+Crow-AMSAA), the cost rate g(t) = (cr*Lambda(t) + co)/t has the closed-form
+minimiser
+
+    t* = alpha * (co / (cr * (beta - 1)))^(1/beta),    beta > 1
+
+with g(t*) = co * beta / ((beta - 1) * t*). The numeric optimiser is held
+to this closed form; beta <= 1 (no wear-out) must give an infinite
+interval.
+Reference: https://reliawiki.org/index.php/Repairable_Systems_Analysis
 """
-Tests Non-Repairable Optimal Replacement Time algorithms.
 
-Uses pytest fixtures located in conftest.py in the tests/ directory.
-"""
+import numpy as np
+import pytest
+import surpyval as surv
 
-# import numpy as np
-# import pytest
-# from surpyval.renewal import Crow
+from repyability import MaintenancePolicy, Repairable
 
-# from repyability.repairable import Repairable
 
-# https://reliawiki.org/index.php/Repairable_Systems_Analysis
-# model = Crow.from_params([1./2.1211e-5, 1.4738])
+def closed_form_interval(alpha, beta, cr, co):
+    return alpha * (co / (cr * (beta - 1.0))) ** (1.0 / beta)
+
+
+def closed_form_cost_rate(alpha, beta, cr, co):
+    t_star = closed_form_interval(alpha, beta, cr, co)
+    return co * beta / ((beta - 1.0) * t_star)
+
+
+def test_cost_and_cost_rate_values():
+    alpha, beta = 100.0, 1.5
+    rep = Repairable(surv.CrowAMSAA.from_params([alpha, beta]))
+    rep.set_repair_and_overhaul_costs(10.0, 1000.0)
+
+    t = 250.0
+    lam = (t / alpha) ** beta
+    assert rep.cost(t) == pytest.approx(10.0 * lam + 1000.0)
+    assert rep.cost_rate(t) == pytest.approx((10.0 * lam + 1000.0) / t)
+
+    # Numpy-style return contract: scalar in -> float, array in -> array.
+    assert isinstance(rep.cost_rate(t), float)
+    arr = rep.cost_rate(np.array([100.0, 250.0]))
+    assert isinstance(arr, np.ndarray)
+    assert arr.shape == (2,)
+
+
+def test_optimal_interval_matches_closed_form():
+    # The second case is the Crow-AMSAA equivalent of the ReliaWiki
+    # repairable-systems example (lambda = 2.1211e-5, beta = 1.4738, in
+    # the Lambda(t) = lambda*t^beta parameterisation, i.e.
+    # alpha = lambda^(-1/beta) ~ 1481.6).
+    cases = [
+        (100.0, 1.5, 10.0, 1000.0),
+        (1481.6, 1.4738, 100.0, 5000.0),
+        (50.0, 3.0, 1.0, 40.0),
+        (2000.0, 2.2, 250.0, 60_000.0),
+    ]
+    for alpha, beta, cr, co in cases:
+        rep = Repairable(surv.CrowAMSAA.from_params([alpha, beta]))
+        rep.set_repair_and_overhaul_costs(cr, co)
+        t_star = rep.find_optimal_overhaul_interval()
+        assert t_star == pytest.approx(
+            closed_form_interval(alpha, beta, cr, co), rel=1e-4
+        )
+        # And it is a genuine minimum: cheaper than nearby intervals.
+        assert rep.cost_rate(t_star) <= rep.cost_rate(0.8 * t_star)
+        assert rep.cost_rate(t_star) <= rep.cost_rate(1.25 * t_star)
+
+
+def test_duane_model_closed_form():
+    # Duane cif: Lambda(t) = b * t^a (surpyval params [a, b]), giving
+    # t* = (co / (cr*b*(a-1)))^(1/a) for a > 1.
+    a, b, cr, co = 1.8, 0.01, 20.0, 4000.0
+    rep = Repairable(surv.Duane.from_params([a, b]))
+    rep.set_repair_and_overhaul_costs(cr, co)
+    expected = (co / (cr * b * (a - 1.0))) ** (1.0 / a)
+    assert rep.find_optimal_overhaul_interval() == pytest.approx(
+        expected, rel=1e-4
+    )
+
+
+def test_no_wear_out_never_overhauls():
+    # beta = 1 is an HPP (constant failure intensity): an overhaul buys
+    # nothing. beta < 1 (reliability growth) makes overhauls strictly
+    # worse. Both must return an infinite interval.
+    for beta in (1.0, 0.8):
+        rep = Repairable(surv.CrowAMSAA.from_params([500.0, beta]))
+        rep.set_repair_and_overhaul_costs(10.0, 1000.0)
+        assert rep.find_optimal_overhaul_interval() == np.inf
+
+
+def test_optimal_overhaul_policy():
+    alpha, beta, cr, co = 100.0, 1.5, 10.0, 1000.0
+    rep = Repairable(surv.CrowAMSAA.from_params([alpha, beta]))
+    rep.set_repair_and_overhaul_costs(cr, co)
+    policy = rep.optimal_overhaul_policy()
+    assert isinstance(policy, MaintenancePolicy)
+    assert policy.interval == pytest.approx(
+        closed_form_interval(alpha, beta, cr, co), rel=1e-4
+    )
+    assert policy.cost_rate == pytest.approx(
+        closed_form_cost_rate(alpha, beta, cr, co), rel=1e-4
+    )
+
+
+def test_policy_when_never_overhauling():
+    # HPP-like unit: the limiting cost rate is minimal repairs at the
+    # long-run rate of occurrence, cr * Lambda(t)/t = cr/alpha for
+    # beta = 1.
+    alpha, cr, co = 500.0, 10.0, 1000.0
+    rep = Repairable(surv.CrowAMSAA.from_params([alpha, 1.0]))
+    rep.set_repair_and_overhaul_costs(cr, co)
+    policy = rep.optimal_overhaul_policy()
+    assert policy.interval == np.inf
+    assert policy.cost_rate == pytest.approx(cr / alpha, rel=1e-3)
+
+
+def test_cost_validation():
+    rep = Repairable(surv.CrowAMSAA.from_params([100.0, 1.5]))
+    with pytest.raises(ValueError, match="less than overhaul"):
+        rep.set_repair_and_overhaul_costs(10.0, 10.0)
+    with pytest.raises(ValueError, match="positive"):
+        rep.set_repair_and_overhaul_costs(0.0, 10.0)
+    with pytest.raises(ValueError, match="costs not set"):
+        rep.find_optimal_overhaul_interval()
+    with pytest.raises(ValueError, match="costs not set"):
+        rep.cost_rate(10.0)
+
+
+def test_model_without_cif_raises():
+    with pytest.raises(ValueError, match="cif"):
+        Repairable(object())


### PR DESCRIPTION
## Summary

Resolves the "fate of the vestigial `Repairable` class" decision (#33) as: **build it out, scoped to component-level maintenance economics.** The two component classes now form a documented pair at the two ends of the repair-effectiveness spectrum — renewal by replacement vs minimal repair — and neither changes the RBD engines.

**`Repairable` (rebuilt, was a 28-line stub):** a minimal-repair ("as bad as old") unit whose failure history is a surpyval recurrence model (`cif`, e.g. Crow-AMSAA, Duane). Finds the overhaul interval minimising the Barlow–Hunter cost rate `(cr·Λ(t) + co)/t`; returns `inf` when the unit doesn't wear out (Λ at most linear — HPP / `beta ≤ 1`), detected by a log-log elasticity check. **Validated against the power-law closed form** `t* = α·(co/(cr·(β−1)))^(1/β)` for both Crow-AMSAA and Duane parameterisations. Previously it returned a raw scipy result object from an unbounded search, its docstring described the wrong class, and its test file was entirely commented out. Costs are now validated (`0 < cr < co`); unset costs raise a clear error.

**`NonRepairable` (polished):** corrected class docstring explaining its two roles (standalone age-replacement optimiser; the per-component renewal representation inside `RepairableRBD`); `find_optimal_replacement()` now returns `inf` for a plain exponential lifetime (memoryless → preventive replacement never pays), matching the existing Weibull `shape ≤ 1` guard; the vectorised `cost_rate` is documented.

**New typed result `MaintenancePolicy`** (`interval`, `cost_rate`) returned by `Repairable.optimal_overhaul_policy()` and the new `NonRepairable.optimal_replacement_policy()`; for `interval = inf` the cost rate is the run-to-failure / repairs-only limiting rate. Exported from the top-level package; added to the API reference.

**Docs:** new user-guide section "Maintenance policies: replacement vs overhaul" — including why `Repairable` is *not* a valid RBD node model (RBD repairs are assumed to renew; minimal repair violates that), which also settles the naming confusion in prose.

## Type of change

- [x] Bug fix (`Repairable` returned a scipy object; wrong docstring)
- [x] New feature (overhaul-interval policy, typed policy results, exponential guard)
- [x] Documentation
- [ ] Refactor / tooling
- [ ] Breaking change (the old `Repairable` API was unusable and untested; no known consumers)

## Checklist

- [x] Tests added/updated (asserting against a reference value where possible) — closed-form Barlow–Hunter optima for Crow-AMSAA & Duane, incl. the ReliaWiki repairable-systems parameters; never-overhaul cases; validation errors
- [x] `black`, `isort`, `flake8`, and `mypy` pass
- [x] `coverage run -m pytest` passes and stays above the coverage gate (298 passed, 91% total; `repairable.py` 47% → 87%)
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Any Monte-Carlo tests are seeded (deterministic) — N/A, the new tests are deterministic (no simulation)

## Notes for reviewers

The optimiser brackets the search scale where `Λ(t) ≈ co/cr` (where any finite optimum must sit), scans ±4 decades on a log grid, and polishes with bounded minimisation — so it's parameterisation-agnostic (works for any `cif`, not just power laws). The closed forms appear only in the tests, keeping the library free of model-name dispatch per the `_model_utils` convention.

Closes #33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUGaeQXKxjjiQ1ULT1ApXS

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUGaeQXKxjjiQ1ULT1ApXS)_