### PR TITLE
Publish the documentation site to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,56 @@
+name: docs
+
+# Build the MkDocs site and publish it to GitHub Pages on every push to
+# master. Pull requests are validated by the strict docs build in
+# actions.yml; this workflow does the actual deployment.
+#
+# One-time repository setup (Settings -> Pages -> Build and deployment):
+# set the Source to "GitHub Actions". No gh-pages branch is used.
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+# Grant the GITHUB_TOKEN the permissions the Pages deployment needs.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment; don't cancel an in-progress publish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: build & deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set-up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install package with docs dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[docs]
+
+      - name: Build docs (strict)
+        run: mkdocs build --strict
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,8 @@ work is tracked as issues in the GitHub repository).
   old nested-dict API (subscript, `keys`/`items`/`values`, `in`, `dict()`).
 - **Documentation site** (MkDocs + mkdocstrings): overview/quickstart, a user
   guide, and an auto-generated API reference. A CI job builds it with
-  `--strict`.
+  `--strict`, and it is published to GitHub Pages
+  (https://derrynknife.github.io/RePyability/) on every push to `master`.
 - **Serialisation.** RBDs round-trip to/from a JSON-friendly structure via
   `to_dict`/`from_dict`/`to_json`/`from_json`, so a diagram can be saved,
   loaded, shared and version-controlled. The structure (edges, k-out-of-n,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # RePyability
 
 [![actions](https://github.com/derrynknife/RePyability/actions/workflows/actions.yml/badge.svg)](https://github.com/derrynknife/RePyability/actions/workflows/actions.yml)
+[![docs](https://github.com/derrynknife/RePyability/actions/workflows/docs.yml/badge.svg)](https://derrynknife.github.io/RePyability/)
 
 Reliability Engineering Tools
 
@@ -14,8 +15,12 @@ pip install repyability
 ```
 
 ## Documentation
-The documentation (overview, user guide, and full API reference) is built with
-[MkDocs](https://www.mkdocs.org/). To build and serve it locally:
+The full documentation — overview, user guide, and API reference — is hosted at
+**[derrynknife.github.io/RePyability](https://derrynknife.github.io/RePyability/)**.
+
+It is built with [MkDocs](https://www.mkdocs.org/) from the sources in `docs/`
+and `mkdocs.yml`, and published to GitHub Pages on every push to `master`. To
+build and serve it locally:
 
 ```bash
 pip install -e .[docs]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: RePyability
 site_description: Reliability engineering tools for Python
+site_url: https://derrynknife.github.io/RePyability/
 repo_url: https://github.com/derrynknife/RePyability
 repo_name: derrynknife/RePyability
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ docs = [
 
 [project.urls]
 Homepage = "https://github.com/derrynknife/RePyability"
+Documentation = "https://derrynknife.github.io/RePyability/"
 Repository = "https://github.com/derrynknife/RePyability"
 Issues = "https://github.com/derrynknife/RePyability/issues"
 


### PR DESCRIPTION
## Summary

The MkDocs-Material site built under `--strict` in CI but wasn't hosted anywhere. This adds a deploy workflow and wires up the links, so the docs are published and discoverable.

- **`.github/workflows/docs.yml`** — builds the site and deploys it to GitHub Pages on every push to `master`, using the modern GitHub Actions Pages deployment (`upload-pages-artifact` + `deploy-pages`; no `gh-pages` branch). Pull requests stay validated by the existing strict docs build in `actions.yml`; this workflow only deploys.
- **`mkdocs.yml`** — set `site_url` (correct canonical URLs + sitemap).
- **`pyproject.toml`** — add the `Documentation` project URL, so it surfaces on the PyPI sidebar.
- **`README.md`** — add a docs badge and point the Documentation section at the hosted site.
- **`CHANGELOG.md`** — note the published site.

The site will be served at **https://derrynknife.github.io/RePyability/**.

## ⚠️ One-time repository setting required

Before the first deploy can succeed, set the Pages source to GitHub Actions:
**Settings → Pages → Build and deployment → Source: _GitHub Actions_.**

Until that's set, the `docs` workflow will run on `master` but fail at the deploy step (with a "Pages not enabled" style error); re-running it after flipping the setting publishes the site. Nothing else in CI is affected.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [x] Refactor / tooling (CI)
- [ ] Breaking change

## Checklist

- [ ] Tests added/updated — N/A, docs/CI only (no Python changed)
- [x] `black`, `isort`, `flake8`, and `mypy` pass (no Python changed)
- [ ] `coverage run -m pytest` — N/A
- [x] `CHANGELOG.md` updated
- [ ] Any Monte-Carlo tests are seeded — N/A

## Notes for reviewers

Verified locally: the deploy workflow YAML parses, `pyproject.toml` parses with the new URL, and `mkdocs build --strict` passes with `site_url` set. The actual Pages deployment can only run post-merge (the workflow is `master`-only) and after the one-time setting above. `site/` is already gitignored, so no built output is committed.

Closes #31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUGaeQXKxjjiQ1ULT1ApXS

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUGaeQXKxjjiQ1ULT1ApXS)_