### PR TITLE
docs: self-enable GitHub Pages in the deploy workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,6 +33,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Enable Pages (with the GitHub Actions build type) if it isn't already,
+      # using the workflow's pages:write token — so no manual repo setting is
+      # needed. Harmless once Pages is enabled.
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+        with:
+          enablement: true
+
       - name: Set-up Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary

Follow-up to #50. The docs deploy was failing at the publish step because GitHub Pages wasn't enabled for the repo (the one-time **Settings → Pages → Source: GitHub Actions** toggle). This adds `actions/configure-pages@v5` with `enablement: true` so the workflow enables Pages itself — using the `pages: write` token it already has — removing the manual step. The step is a no-op once Pages is enabled.

Merging this triggers the `docs` workflow on `master`, which should now self-enable Pages and publish the site to https://derrynknife.github.io/RePyability/.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor / tooling (CI)
- [ ] Breaking change

## Checklist

- [ ] Tests — N/A (CI workflow only)
- [x] `black`/`isort`/`flake8`/`mypy` unaffected (no Python changed)
- [ ] Coverage — N/A
- [ ] CHANGELOG — N/A (no library change)

## Notes for reviewers

If GitHub still refuses programmatic enablement on this account (rare for a personal public repo), the fallback is the manual toggle at https://github.com/derrynknife/RePyability/settings/pages — but this should remove the need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUGaeQXKxjjiQ1ULT1ApXS

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUGaeQXKxjjiQ1ULT1ApXS)_