### PR TITLE
Release prep: roll CHANGELOG into [0.5.0]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_Nothing yet._
+
+## [0.5.0] - 2026-07-18
+
 This release focuses on packaging, tooling, correctness and API-consistency
 foundations (Phases 0 and 1 of the project's development plan; forward-looking
 work is tracked as issues in the GitHub repository).


### PR DESCRIPTION
## Summary

Prep for cutting the 0.5.0 release (#32). Rolls the accumulated `[Unreleased]` notes under a dated `## [0.5.0] - 2026-07-18` heading and opens a fresh empty `[Unreleased]` section. The version in `repyability/_version.py` is already `0.5.0`.

This is the only in-repo change needed; the remaining release steps are the PyPI trusted-publisher setup and publishing the GitHub Release (which triggers `release.yml`).

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation (changelog)
- [ ] Refactor / tooling
- [ ] Breaking change

## Checklist

- [ ] Tests — N/A
- [x] `black`/`isort`/`flake8`/`mypy` unaffected (no Python changed)
- [ ] Coverage — N/A
- [x] `CHANGELOG.md` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUGaeQXKxjjiQ1ULT1ApXS

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUGaeQXKxjjiQ1ULT1ApXS)_