### PR TITLE
Fix broken clean install (0.5.1): require surpyval >= 0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Nothing yet._
 
+## [0.5.1] - 2026-07-18
+
+### Fixed
+- **Clean installs of 0.5.0 could not `import repyability`.** Importing
+  `surpyval` (which RePyability does at load time) failed with
+  `ModuleNotFoundError: No module named 'joblib'`: surpyval 0.11 imported
+  joblib unconditionally without declaring it as a dependency, and
+  RePyability listed joblib only in its `dev` extra, so a plain
+  `pip install repyability` never pulled it in. Fixed by requiring
+  `surpyval >= 0.13`, which declares `joblib` as a dependency — a plain
+  install now imports cleanly.
+
+### Changed
+- Bumped the `surpyval` requirement from `>=0.11.1,<0.12` to `>=0.13,<0.14`.
+  surpyval 0.13 relocated its recurrent-event models
+  (`surpyval.CrowAMSAA` → `surpyval.recurrent.CrowAMSAA`, and likewise
+  `Duane`); `Repairable` is unaffected (it only needs an object exposing
+  `cif`), and the docs and tests were updated to the new import path.
+- Dropped the now-redundant `joblib` entry from the `dev` extra (surpyval
+  provides it transitively).
+
 ## [0.5.0] - 2026-07-18
 
 This release focuses on packaging, tooling, correctness and API-consistency

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -245,10 +245,10 @@ unit. The optimal overhaul interval minimises
 the classic Barlow-Hunter policy:
 
 ```python
-import surpyval as surv
+from surpyval.recurrent import CrowAMSAA
 from repyability import Repairable
 
-unit = Repairable(surv.CrowAMSAA.from_params([1500, 1.5]))
+unit = Repairable(CrowAMSAA.from_params([1500, 1.5]))
 unit.set_repair_and_overhaul_costs(100, 10_000)
 
 unit.find_optimal_overhaul_interval()   # inf if the unit never wears out

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "numpy>=2.0,<3",
     "scipy>=1.7",
     "networkx>=3.0",
-    "surpyval>=0.11.1,<0.12",
+    "surpyval>=0.13,<0.14",
     "tqdm>=4.64",
 ]
 
@@ -49,10 +49,6 @@ dev = [
     "pytest>=7.0",
     "coverage>=7.0",
     "pre-commit>=3.0",
-    # Testing-only: the suite imports surpyval, which transitively pulls in its
-    # RandomSurvivalForest (and hence joblib). Not a runtime dependency of
-    # RePyability.
-    "joblib>=1.0",
 ]
 docs = [
     "mkdocs-material>=9.0",

--- a/repyability/_version.py
+++ b/repyability/_version.py
@@ -5,4 +5,4 @@ Kept deliberately free of imports so the build backend can read
 dependencies) via ``[tool.setuptools.dynamic]`` in ``pyproject.toml``.
 """
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"

--- a/repyability/tests/test_repairable.py
+++ b/repyability/tests/test_repairable.py
@@ -15,7 +15,7 @@ Reference: https://reliawiki.org/index.php/Repairable_Systems_Analysis
 
 import numpy as np
 import pytest
-import surpyval as surv
+from surpyval.recurrent import CrowAMSAA, Duane
 
 from repyability import MaintenancePolicy, Repairable
 
@@ -31,7 +31,7 @@ def closed_form_cost_rate(alpha, beta, cr, co):
 
 def test_cost_and_cost_rate_values():
     alpha, beta = 100.0, 1.5
-    rep = Repairable(surv.CrowAMSAA.from_params([alpha, beta]))
+    rep = Repairable(CrowAMSAA.from_params([alpha, beta]))
     rep.set_repair_and_overhaul_costs(10.0, 1000.0)
 
     t = 250.0
@@ -58,7 +58,7 @@ def test_optimal_interval_matches_closed_form():
         (2000.0, 2.2, 250.0, 60_000.0),
     ]
     for alpha, beta, cr, co in cases:
-        rep = Repairable(surv.CrowAMSAA.from_params([alpha, beta]))
+        rep = Repairable(CrowAMSAA.from_params([alpha, beta]))
         rep.set_repair_and_overhaul_costs(cr, co)
         t_star = rep.find_optimal_overhaul_interval()
         assert t_star == pytest.approx(
@@ -73,7 +73,7 @@ def test_duane_model_closed_form():
     # Duane cif: Lambda(t) = b * t^a (surpyval params [a, b]), giving
     # t* = (co / (cr*b*(a-1)))^(1/a) for a > 1.
     a, b, cr, co = 1.8, 0.01, 20.0, 4000.0
-    rep = Repairable(surv.Duane.from_params([a, b]))
+    rep = Repairable(Duane.from_params([a, b]))
     rep.set_repair_and_overhaul_costs(cr, co)
     expected = (co / (cr * b * (a - 1.0))) ** (1.0 / a)
     assert rep.find_optimal_overhaul_interval() == pytest.approx(
@@ -86,14 +86,14 @@ def test_no_wear_out_never_overhauls():
     # nothing. beta < 1 (reliability growth) makes overhauls strictly
     # worse. Both must return an infinite interval.
     for beta in (1.0, 0.8):
-        rep = Repairable(surv.CrowAMSAA.from_params([500.0, beta]))
+        rep = Repairable(CrowAMSAA.from_params([500.0, beta]))
         rep.set_repair_and_overhaul_costs(10.0, 1000.0)
         assert rep.find_optimal_overhaul_interval() == np.inf
 
 
 def test_optimal_overhaul_policy():
     alpha, beta, cr, co = 100.0, 1.5, 10.0, 1000.0
-    rep = Repairable(surv.CrowAMSAA.from_params([alpha, beta]))
+    rep = Repairable(CrowAMSAA.from_params([alpha, beta]))
     rep.set_repair_and_overhaul_costs(cr, co)
     policy = rep.optimal_overhaul_policy()
     assert isinstance(policy, MaintenancePolicy)
@@ -110,7 +110,7 @@ def test_policy_when_never_overhauling():
     # long-run rate of occurrence, cr * Lambda(t)/t = cr/alpha for
     # beta = 1.
     alpha, cr, co = 500.0, 10.0, 1000.0
-    rep = Repairable(surv.CrowAMSAA.from_params([alpha, 1.0]))
+    rep = Repairable(CrowAMSAA.from_params([alpha, 1.0]))
     rep.set_repair_and_overhaul_costs(cr, co)
     policy = rep.optimal_overhaul_policy()
     assert policy.interval == np.inf
@@ -118,7 +118,7 @@ def test_policy_when_never_overhauling():
 
 
 def test_cost_validation():
-    rep = Repairable(surv.CrowAMSAA.from_params([100.0, 1.5]))
+    rep = Repairable(CrowAMSAA.from_params([100.0, 1.5]))
     with pytest.raises(ValueError, match="less than overhaul"):
         rep.set_repair_and_overhaul_costs(10.0, 10.0)
     with pytest.raises(ValueError, match="positive"):


### PR DESCRIPTION
## Summary

**0.5.0 can't be imported after a plain `pip install`** — a fresh-venv install surfaced it:

```
$ pip install repyability==0.5.0   # succeeds
$ python -c "import repyability"
ModuleNotFoundError: No module named 'joblib'
```

Importing `surpyval` (which RePyability does at load time) fails because surpyval 0.11 imports `joblib` unconditionally but doesn't declare it, and we had joblib only in the `dev` extra — so a runtime install never pulled it in. It only "worked" in environments that already had joblib (dev/CI), which is why it slipped past.

**Fix:** require `surpyval >= 0.13`, which now declares `joblib` as a dependency — a plain `pip install repyability` pulls it in transitively and imports cleanly. Ships as **0.5.1** (0.5.0 is immutable on PyPI).

Changes:
- `pyproject.toml`: `surpyval>=0.11.1,<0.12` → `>=0.13,<0.14`; drop the now-redundant `joblib` from the `dev` extra (surpyval provides it).
- `_version.py`: 0.5.0 → 0.5.1; `CHANGELOG.md`: `[0.5.1]` section.
- surpyval 0.13 relocated its recurrent-event models (`surpyval.CrowAMSAA` → `surpyval.recurrent.CrowAMSAA`, likewise `Duane`). `Repairable` is **unaffected** (duck-typed on `cif`); only `test_repairable.py` and one docs example needed the new import path — behaviour is identical (verified: 0.13's `cif` values match the closed forms exactly).

## Verification (local, Python 3.11, surpyval 0.13.0)
- Fresh venv: `pip install .` → `import repyability` → **0.5.1, public API OK**, `surpyval 0.13.0 | joblib 1.5.3`.
- **298 tests pass**; `black`/`isort`/`flake8`/`mypy` clean.

## Type of change
- [x] Bug fix (broken install/import)
- [ ] New feature
- [x] Documentation (changelog + guide example)
- [ ] Breaking change

## Checklist
- [x] Tests updated (recurrent-model import path); full suite green against surpyval 0.13
- [x] `black`, `isort`, `flake8`, `mypy` pass
- [x] `coverage run -m pytest` passes and stays above the gate
- [x] `CHANGELOG.md` updated (`[0.5.1]`)
- [x] MC tests seeded (unchanged)

## Note
After merge, this needs a **v0.5.1 GitHub Release** (same flow as 0.5.0) to publish the fix to PyPI. The trusted publisher is already configured, so it's just Draft → tag `v0.5.1` → publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUGaeQXKxjjiQ1ULT1ApXS

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUGaeQXKxjjiQ1ULT1ApXS)_