### PR TITLE
Add structural importance and parameter sensitivity (#42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet._
+### Added
+- **`structural_importance()`** on every RBD: the Birnbaum importance with all
+  node reliabilities at 1/2 — a probability-free, design-time ranking of where
+  each node is pivotal in the structure. It depends only on the diagram, so it
+  is identical for a `NonRepairableRBD` and a `RepairableRBD` on the same
+  layout, and honours the usual `working_nodes`/`broken_nodes` conditioning.
+- **`parameter_sensitivity(t)`** on `NonRepairableRBD`: the sensitivity of
+  system reliability to each node's distribution parameters,
+  `dR_sys/d_theta = birnbaum_importance(node) * d sf_node/d_theta`. The
+  parameter derivative is computed numerically (via surpyval's `from_params`),
+  so it applies to any parametric model without per-distribution formulae.
+  Composite and non-parametric nodes are omitted; forced nodes report zero.
 
 ## [0.5.1] - 2026-07-18
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -110,6 +110,41 @@ the analysis, e.g. `rbd.birnbaum_importance(t, broken_nodes=["pump2"])`.
 The same measures exist on `RepairableRBD`, evaluated at the nodes' long-run
 availabilities (no time argument): `rbd.birnbaum_importance()`, etc.
 
+### Structural importance (design-time, model-free)
+
+```python
+rbd.structural_importance()
+```
+
+`structural_importance` is the Birnbaum importance with every node reliability
+set to 1/2 — the fraction of the states of the *other* nodes in which a node is
+pivotal. It depends only on the diagram, not on any failure model, so you can
+rank where redundancy matters most **before** any life data exists. Being a
+structural property, it is identical for a `NonRepairableRBD` and a
+`RepairableRBD` built on the same diagram. For example, a node in series with a
+parallel pair scores `0.75` against the pair's `0.25` each. It accepts the same
+`working_nodes`/`broken_nodes` conditioning.
+
+### Parameter sensitivity (which fitted parameter matters most)
+
+```python
+rbd.parameter_sensitivity(t)
+# {node: {"alpha": dR_sys/d_alpha, "beta": ...}, ...}
+```
+
+`parameter_sensitivity` (on `NonRepairableRBD`) reports how much the system
+reliability moves per unit change in each node's distribution parameters:
+`dR_sys/d_theta = birnbaum_importance(node) * d sf_node/d_theta`. The parameter
+derivative is taken numerically (rebuilding the distribution with a perturbed
+parameter), so it works for any surpyval parametric model without
+per-distribution formulae. Use it to target data collection or to gauge the
+impact of estimation uncertainty. Composite nodes (a nested RBD, a standby
+arrangement, a repeated node) and fitted non-parametric models have no
+parameters to perturb and are omitted; a node forced via
+`working_nodes`/`broken_nodes` is pinned regardless of its parameters and so
+reports zero. As elsewhere, a scalar `t` returns floats and an array returns
+numpy arrays.
+
 ## Repairable systems and availability
 
 A [`RepairableRBD`][repyability.RepairableRBD] takes components with both a

--- a/repyability/rbd/_model_utils.py
+++ b/repyability/rbd/_model_utils.py
@@ -57,3 +57,30 @@ def model_mean(model) -> float:
         if distribution_name(model) == "ExactEventTime":
             return float(np.atleast_1d(model.params)[0])
         raise
+
+
+def parametric_spec(model):
+    """Return ``(surpyval_class, params, param_names)`` for a parametric node
+    model, or ``None`` when it has no reconstructable distribution parameters
+    (a ``StandbyModel``, ``RepeatedNode``, nested RBD, a repeated node's source
+    name, the perfect-reliability helpers, or a fitted non-parametric model).
+
+    Used by parameter-sensitivity analysis to rebuild a distribution with a
+    perturbed parameter. It is faithful for exactly the models
+    ``serialisation`` round-trips (surpyval parametric distributions), since it
+    goes through the same ``dist name`` + ``from_params`` reconstruction.
+    """
+    import surpyval
+
+    name = distribution_name(model)
+    if name is None:
+        return None
+    cls = getattr(surpyval, name, None)
+    if cls is None or not hasattr(cls, "from_params"):
+        return None
+    params = [float(p) for p in np.atleast_1d(model.params)]
+    dist = getattr(model, "dist", None)
+    names = getattr(dist, "param_names", None)
+    if not names or len(list(names)) != len(params):
+        names = [f"param{i}" for i in range(len(params))]
+    return cls, params, list(names)

--- a/repyability/rbd/non_repairable_rbd.py
+++ b/repyability/rbd/non_repairable_rbd.py
@@ -24,7 +24,7 @@ from surpyval import NonParametric
 
 from repyability.utils.wrappers import conditional_survival, numpy_seed
 
-from ._model_utils import is_fixed_probability
+from ._model_utils import is_fixed_probability, parametric_spec
 from .helper_classes import PerfectReliability, PerfectUnreliability
 from .rbd import RBD
 from .repeated_node import RepeatedNode
@@ -76,6 +76,42 @@ def check_x(func):
         return result
 
     return wrap
+
+
+def _dsf_dparam(cls, params, j, x_arr, rel_step) -> np.ndarray:
+    """Partial derivative of a distribution's ``sf`` at ``x_arr`` with respect
+    to its ``j``-th parameter, by finite difference.
+
+    ``cls.from_params`` rebuilds the distribution with a perturbed parameter,
+    so this works for any surpyval parametric distribution without hard-coding
+    per-distribution derivative formulae. A central difference is used where
+    both perturbations are valid; if one perturbation falls outside a
+    parameter's admissible range (e.g. a probability leaving ``[0, 1]``) it
+    falls back to a one-sided difference about the unperturbed value.
+    """
+    theta = params[j]
+    h = rel_step * abs(theta) if theta != 0.0 else rel_step
+
+    def perturbed(delta):
+        trial = list(params)
+        trial[j] = theta + delta
+        try:
+            return np.asarray(cls.from_params(trial).sf(x_arr), dtype=float)
+        except Exception:
+            return None
+
+    up = perturbed(h)
+    down = perturbed(-h)
+    if up is not None and down is not None:
+        return (up - down) / (2.0 * h)
+    # A perturbation hit a parameter bound; fall back to a one-sided
+    # difference about the unperturbed value.
+    base = np.asarray(cls.from_params(list(params)).sf(x_arr), dtype=float)
+    if up is not None:
+        return (up - base) / h
+    if down is not None:
+        return (base - down) / h
+    return np.full(x_arr.shape, np.nan)
 
 
 class NonRepairableRBD(RBD):
@@ -1004,3 +1040,93 @@ class NonRepairableRBD(RBD):
             stacklevel=2,
         )
         return self.fussell_vesely(x, fv_type)
+
+    def parameter_sensitivity(
+        self,
+        x: Optional[ArrayLike] = None,
+        working_nodes: Optional[Collection[Hashable]] = None,
+        broken_nodes: Optional[Collection[Hashable]] = None,
+        rel_step: float = 1e-5,
+    ) -> Dict[Any, Dict[str, Union[float, np.ndarray]]]:
+        """Sensitivity of the system reliability to each node's distribution
+        parameters at time/s ``x``.
+
+        For node ``i`` with parameter ``theta``, the sensitivity is
+
+        ``d R_sys / d theta = B_i(x) * d sf_i(x; theta) / d theta``
+
+        where ``B_i`` is the Birnbaum importance of node ``i`` (how much the
+        system reliability moves per unit change in that node's reliability)
+        and ``d sf_i / d theta`` is how much the node's reliability moves per
+        unit change in the parameter. The parameter derivative is taken
+        numerically (a central finite difference, rebuilding the distribution
+        with ``from_params``), so it applies to any parametric surpyval model
+        without per-distribution formulae. It answers "which fitted parameter,
+        if it were a little different, would move system reliability the most"
+        -- e.g. to target data collection or to gauge the impact of estimation
+        uncertainty.
+
+        Only nodes with reconstructable distribution parameters are included;
+        composite nodes (a nested RBD, a standby arrangement, a repeated node)
+        and fitted non-parametric models have no parameters to perturb and are
+        omitted. A node forced via ``working_nodes``/``broken_nodes`` is pinned
+        independently of its parameters, so its sensitivities are reported as
+        zero.
+
+        Parameters
+        ----------
+        x : ArrayLike
+            Time/s as a number or iterable.
+        working_nodes : Collection[Hashable], optional
+            Condition on these nodes being perfectly reliable, by default None.
+        broken_nodes : Collection[Hashable], optional
+            Condition on these nodes having failed, by default None.
+        rel_step : float, optional
+            Relative step used for the finite difference, by default ``1e-5``.
+
+        Returns
+        -------
+        dict[Any, dict[str, float | np.ndarray]]
+            ``{node_name: {parameter_name: sensitivity}}``. Sensitivities are
+            floats for scalar ``x`` and arrays for array ``x``.
+        """
+        if x is None:
+            if self.is_fixed:
+                x = 1.0
+            else:
+                raise ValueError(
+                    "x is required: this RBD is time-varying (at least one "
+                    "node model's probability depends on time)."
+                )
+        scalar_in = np.ndim(x) == 0
+        x_arr = np.atleast_1d(np.asarray(x, dtype=float))
+
+        # Birnbaum importance validates the override sets and honours them.
+        birnbaum = self.birnbaum_importance(x_arr, working_nodes, broken_nodes)
+        forced = set(working_nodes or ()) | set(broken_nodes or ())
+
+        def _out(value) -> Union[float, np.ndarray]:
+            arr = np.asarray(value, dtype=float)
+            return float(arr.reshape(-1)[0]) if scalar_in else arr
+
+        sensitivities: Dict[Any, Dict[str, Union[float, np.ndarray]]] = {}
+        for node_name, model in self.reliabilities.items():
+            spec = parametric_spec(model)
+            if spec is None:
+                # Composite / non-parametric node: no parameters to perturb.
+                continue
+            cls, params, names = spec
+            node_out: Dict[str, Union[float, np.ndarray]] = {}
+            if node_name in forced:
+                # Pinned regardless of its parameters -> zero sensitivity.
+                zero = np.zeros_like(x_arr)
+                for name in names:
+                    node_out[name] = _out(zero)
+                sensitivities[node_name] = node_out
+                continue
+            b_i = np.asarray(birnbaum[node_name], dtype=float)
+            for j, name in enumerate(names):
+                dsf = _dsf_dparam(cls, params, j, x_arr, rel_step)
+                node_out[name] = _out(b_i * dsf)
+            sensitivities[node_name] = node_out
+        return sensitivities

--- a/repyability/rbd/rbd.py
+++ b/repyability/rbd/rbd.py
@@ -635,6 +635,40 @@ class RBD:
         """Returns the list of (intermediate) node names of the RBD."""
         return list(self.nodes)
 
+    def structural_importance(
+        self,
+        working_nodes: Optional[Iterable[Hashable]] = None,
+        broken_nodes: Optional[Iterable[Hashable]] = None,
+    ) -> dict[Any, float]:
+        """Structural (probability-free) importance of every node.
+
+        The fraction of the states of the *other* nodes in which the node is
+        pivotal -- the system works when the node works and fails when it
+        fails, holding the others fixed. Equivalently it is the Birnbaum
+        importance with every node reliability at 1/2, so it depends only on
+        the RBD's structure and not on any failure model -- useful at design
+        time, before any life data exists. It is a structural property, so it
+        is the same for a ``NonRepairableRBD`` and a ``RepairableRBD`` with the
+        same diagram.
+
+        ``working_nodes``/``broken_nodes`` condition on those nodes being
+        forced up/down (validated as elsewhere).
+
+        Returns
+        -------
+        dict[Any, float]
+            Node name -> structural importance, in ``[0, 1]``.
+        """
+        node_probabilities = {node: np.full(1, 0.5) for node in self.nodes}
+        node_probabilities = self._probabilities_with_overrides(
+            node_probabilities, working_nodes, broken_nodes
+        )
+        importance = self._birnbaum_importance(node_probabilities)
+        return {
+            node: float(np.asarray(value).reshape(-1)[0])
+            for node, value in importance.items()
+        }
+
     # -- Serialisation -----------------------------------------------------
 
     def to_dict(self) -> dict:

--- a/repyability/tests/test_parameter_sensitivity.py
+++ b/repyability/tests/test_parameter_sensitivity.py
@@ -1,0 +1,164 @@
+"""
+Tests NonRepairableRBD.parameter_sensitivity().
+
+The sensitivity of system reliability to a node parameter is the Birnbaum
+importance of the node times the derivative of the node's sf with respect to
+the parameter. The parameter derivative is checked against closed-form
+expressions for Weibull, Exponential and FixedEventProbability.
+"""
+
+import numpy as np
+import pytest
+import surpyval as surv
+from surpyval import FixedEventProbability
+
+from repyability.rbd.non_repairable_rbd import NonRepairableRBD
+from repyability.rbd.standby_node import StandbyModel
+
+
+def weibull_dsf_dalpha(t, alpha, beta):
+    sf = np.exp(-((t / alpha) ** beta))
+    return sf * (beta / alpha) * (t / alpha) ** beta
+
+
+def weibull_dsf_dbeta(t, alpha, beta):
+    sf = np.exp(-((t / alpha) ** beta))
+    return sf * (-((t / alpha) ** beta) * np.log(t / alpha))
+
+
+def exponential_dsf_dfailure_rate(t, failure_rate):
+    return -t * np.exp(-failure_rate * t)
+
+
+def test_weibull_parameter_sensitivity(rbd_series: NonRepairableRBD):
+    """Sensitivity == Birnbaum importance * analytic dsf/dparam for a
+    Weibull series system."""
+    t = 10.0
+    sens = rbd_series.parameter_sensitivity(t)
+    birnbaum = rbd_series.birnbaum_importance(t)
+    params = {2: (20.0, 2.0), 3: (100.0, 3.0), 4: (50.0, 20.0)}
+    for node, (alpha, beta) in params.items():
+        assert set(sens[node]) == {"alpha", "beta"}
+        assert sens[node]["alpha"] == pytest.approx(
+            birnbaum[node] * weibull_dsf_dalpha(t, alpha, beta), rel=1e-4
+        )
+        assert sens[node]["beta"] == pytest.approx(
+            birnbaum[node] * weibull_dsf_dbeta(t, alpha, beta), rel=1e-4
+        )
+
+
+def test_exponential_parameter_sensitivity():
+    """Sensitivity of a single Exponential node matches the closed form."""
+    rbd = NonRepairableRBD(
+        [("s", "a"), ("a", "b"), ("b", "t")],
+        {
+            "a": surv.Exponential.from_params([0.1]),
+            "b": surv.Exponential.from_params([0.2]),
+        },
+    )
+    t = 5.0
+    sens = rbd.parameter_sensitivity(t)
+    birnbaum = rbd.birnbaum_importance(t)
+    for node, rate in {"a": 0.1, "b": 0.2}.items():
+        assert set(sens[node]) == {"failure_rate"}
+        assert sens[node]["failure_rate"] == pytest.approx(
+            birnbaum[node] * exponential_dsf_dfailure_rate(t, rate),
+            rel=1e-4,
+        )
+
+
+def test_fixed_probability_parameter_sensitivity(
+    rbd_parallel: NonRepairableRBD,
+):
+    """For a fixed event probability, sf = 1 - p so dsf/dp = -1 and the
+    sensitivity is exactly minus the Birnbaum importance."""
+    sens = rbd_parallel.parameter_sensitivity(1.0)
+    birnbaum = rbd_parallel.birnbaum_importance(1.0)
+    for node in (2, 3, 4):
+        assert set(sens[node]) == {"p"}
+        assert sens[node]["p"] == pytest.approx(-birnbaum[node], rel=1e-4)
+
+
+def test_scalar_input_returns_floats(rbd_series: NonRepairableRBD):
+    sens = rbd_series.parameter_sensitivity(10.0)
+    for node_params in sens.values():
+        for value in node_params.values():
+            assert isinstance(value, float)
+
+
+def test_array_input_returns_arrays(rbd_series: NonRepairableRBD):
+    x = np.array([5.0, 10.0, 15.0])
+    sens = rbd_series.parameter_sensitivity(x)
+    for node_params in sens.values():
+        for value in node_params.values():
+            assert isinstance(value, np.ndarray)
+            assert value.shape == x.shape
+
+
+def test_composite_node_omitted():
+    """A standby (composite) node has no reconstructable parameters and is
+    omitted from the result."""
+    rbd = NonRepairableRBD(
+        [(1, 2), (2, 3), (3, 4), (4, 5)],
+        {
+            2: surv.Weibull.from_params([20, 2]),
+            3: StandbyModel(
+                [
+                    surv.Weibull.from_params([5, 1.1]),
+                    surv.Weibull.from_params([5, 1.1]),
+                ]
+            ),
+            4: surv.Weibull.from_params([50, 20]),
+        },
+    )
+    sens = rbd.parameter_sensitivity(5.0)
+    assert set(sens) == {2, 4}
+
+
+def test_repeated_node_omitted(
+    rbd_repeated_component_parallel: NonRepairableRBD,
+):
+    """A repeated node references another node's model rather than owning its
+    own parameters, so it is omitted."""
+    sens = rbd_repeated_component_parallel.parameter_sensitivity(1.0)
+    # Node 5 repeats node 2; only the genuine parametric nodes appear.
+    assert 5 not in sens
+    assert {2, 3, 4}.issubset(set(sens))
+
+
+def test_forced_node_has_zero_sensitivity(rbd_series: NonRepairableRBD):
+    """A node pinned via working_nodes/broken_nodes is independent of its
+    parameters, so its sensitivities are zero."""
+    sens = rbd_series.parameter_sensitivity(10.0, working_nodes=[2])
+    assert sens[2] == {"alpha": 0.0, "beta": 0.0}
+    broken = rbd_series.parameter_sensitivity(10.0, broken_nodes=[3])
+    assert broken[3] == {"alpha": 0.0, "beta": 0.0}
+
+
+def test_boundary_parameter_uses_one_sided_difference():
+    """A fixed probability pinned near its upper bound cannot be perturbed
+    upward (p + h would exceed 1); the finite difference falls back to a
+    one-sided estimate instead of raising, and still recovers dsf/dp = -1."""
+    rbd = NonRepairableRBD(
+        [("s", "a"), ("a", "t")],
+        {"a": FixedEventProbability.from_params(0.999999)},
+    )
+    sens = rbd.parameter_sensitivity(1.0)
+    # Single series node: Birnbaum importance is 1, dsf/dp = -1.
+    assert sens["a"]["p"] == pytest.approx(-1.0, rel=1e-3)
+
+
+def test_x_required_for_time_varying(rbd_series: NonRepairableRBD):
+    with pytest.raises(ValueError):
+        rbd_series.parameter_sensitivity()
+
+
+def test_x_optional_for_fixed(rbd_parallel: NonRepairableRBD):
+    """A fixed-probability RBD does not require x."""
+    sens = rbd_parallel.parameter_sensitivity()
+    assert set(sens) == {2, 3, 4}
+
+
+def test_unknown_node_override_raises(rbd_series: NonRepairableRBD):
+    with pytest.raises(ValueError):
+        rbd_series.parameter_sensitivity(10.0, broken_nodes=["nope"])

--- a/repyability/tests/test_structural_importance.py
+++ b/repyability/tests/test_structural_importance.py
@@ -1,0 +1,158 @@
+"""
+Tests RBD.structural_importance().
+
+Structural importance is the Birnbaum importance evaluated with every node
+reliability at 1/2, so it depends only on the diagram, not on any failure
+model. The expected values below are worked by hand from the structure.
+"""
+
+import numpy as np
+import pytest
+import surpyval as surv
+from surpyval import FixedEventProbability
+
+from repyability.rbd.non_repairable_rbd import NonRepairableRBD
+from repyability.rbd.repairable_rbd import RepairableRBD
+
+
+def test_series_structural_importance(rbd_series: NonRepairableRBD):
+    """Every node in an n-series system has structural importance
+    0.5**(n-1); here n=3 so each is 0.25."""
+    si = rbd_series.structural_importance()
+    assert set(si) == {2, 3, 4}
+    for value in si.values():
+        assert value == pytest.approx(0.25)
+
+
+def test_parallel_structural_importance(rbd_parallel: NonRepairableRBD):
+    """Every node in an n-parallel system has structural importance
+    0.5**(n-1); here n=3 so each is 0.25."""
+    si = rbd_parallel.structural_importance()
+    assert set(si) == {2, 3, 4}
+    for value in si.values():
+        assert value == pytest.approx(0.25)
+
+
+def test_series_parallel_structural_importance():
+    """Node 1 in series with a parallel block of nodes 2 and 3.
+
+    System = R1 * (1 - (1-R2)(1-R3)). At R=1/2:
+      B_1 = 1 - (1-R2)(1-R3) = 0.75
+      B_2 = R1 * (1 - R3)    = 0.25
+      B_3 = R1 * (1 - R2)    = 0.25
+    """
+    rbd = NonRepairableRBD(
+        [("s", 1), (1, 2), (1, 3), (2, "t"), (3, "t")],
+        {
+            1: FixedEventProbability.from_params(1 - 0.9),
+            2: FixedEventProbability.from_params(1 - 0.8),
+            3: FixedEventProbability.from_params(1 - 0.85),
+        },
+    )
+    si = rbd.structural_importance()
+    assert si[1] == pytest.approx(0.75)
+    assert si[2] == pytest.approx(0.25)
+    assert si[3] == pytest.approx(0.25)
+
+
+def test_koon_structural_importance():
+    """A 2-out-of-3 vote on nodes 1, 2, 3 in series with a valve.
+
+    For a pure 2oo3 at R=1/2 each component has Birnbaum importance 0.5, but
+    the trailing series valve halves it (B = 0.5 * R_valve = 0.25), while the
+    valve sees the 2oo3 block (B = P(2oo3 works at 0.5) = 0.5).
+    """
+    rbd = NonRepairableRBD(
+        [
+            ("s", 1),
+            ("s", 2),
+            ("s", 3),
+            (1, "v"),
+            (2, "v"),
+            (3, "v"),
+            ("v", "t"),
+        ],
+        {
+            1: FixedEventProbability.from_params(1 - 0.85),
+            2: FixedEventProbability.from_params(1 - 0.8),
+            3: FixedEventProbability.from_params(1 - 0.9),
+            "v": FixedEventProbability.from_params(1 - 0.85),
+        },
+        k={"v": 2},
+    )
+    si = rbd.structural_importance()
+    assert si[1] == pytest.approx(0.25)
+    assert si[2] == pytest.approx(0.25)
+    assert si[3] == pytest.approx(0.25)
+    assert si["v"] == pytest.approx(0.5)
+
+
+def test_single_node_structural_importance():
+    """A lone node is always pivotal, so its structural importance is 1."""
+    rbd = NonRepairableRBD(
+        [("s", "a"), ("a", "t")],
+        {"a": FixedEventProbability.from_params(0.1)},
+    )
+    assert rbd.structural_importance()["a"] == pytest.approx(1.0)
+
+
+def test_structural_importance_is_model_free(rbd_series: NonRepairableRBD):
+    """It equals the Birnbaum importance evaluated at reliabilities of 1/2,
+    independent of the actual node models."""
+    si = rbd_series.structural_importance()
+    node_probabilities = {node: np.full(1, 0.5) for node in rbd_series.nodes}
+    birnbaum = rbd_series._birnbaum_importance(node_probabilities)
+    for node, value in si.items():
+        assert value == pytest.approx(float(np.asarray(birnbaum[node])[0]))
+
+
+def test_structural_importance_same_for_repairable():
+    """A structural property: identical for a NonRepairableRBD and a
+    RepairableRBD built on the same diagram."""
+    edges = [("s", 1), (1, 2), (1, 3), (2, "t"), (3, "t")]
+    nonrep = NonRepairableRBD(
+        edges,
+        {
+            1: FixedEventProbability.from_params(1 - 0.9),
+            2: FixedEventProbability.from_params(1 - 0.8),
+            3: FixedEventProbability.from_params(1 - 0.85),
+        },
+    )
+    rep = RepairableRBD(
+        edges,
+        {
+            node: {
+                "reliability": surv.Weibull.from_params([10 * node, 2]),
+                "repairability": surv.Exponential.from_params([0.5]),
+            }
+            for node in (1, 2, 3)
+        },
+    )
+    assert nonrep.structural_importance() == rep.structural_importance()
+
+
+def test_structural_importance_working_node():
+    """Forcing node 1 to work removes its series contribution: the system
+    reduces to the 2||3 parallel block, so nodes 2 and 3 keep 0.25 while the
+    forced node's own value reflects the conditioned structure."""
+    rbd = NonRepairableRBD(
+        [("s", 1), (1, 2), (1, 3), (2, "t"), (3, "t")],
+        {
+            1: FixedEventProbability.from_params(1 - 0.9),
+            2: FixedEventProbability.from_params(1 - 0.8),
+            3: FixedEventProbability.from_params(1 - 0.85),
+        },
+    )
+    si = rbd.structural_importance(working_nodes=[1])
+    # With node 1 pinned up, 2 and 3 each become pivotal exactly when the
+    # other fails: B = 1 - R = 0.5.
+    assert si[2] == pytest.approx(0.5)
+    assert si[3] == pytest.approx(0.5)
+
+
+def test_structural_importance_unknown_node_raises(
+    rbd_series: NonRepairableRBD,
+):
+    """Overrides are validated: an unknown node name raises."""
+    with pytest.raises(ValueError):
+        rbd_series.structural_importance(working_nodes=["not_a_node"])


### PR DESCRIPTION
## Summary

Implements issue #42 — two design-oriented additions to the importance suite.

- **`structural_importance()`** on every `RBD` (base class, so both
  `NonRepairableRBD` and `RepairableRBD` inherit it). It is the Birnbaum
  importance evaluated with all node reliabilities at ½ — a probability-free
  measure of how pivotal each node is in the diagram. It needs no failure
  model, so it ranks where redundancy matters *before* any life data exists,
  and (being purely structural) is identical for a `NonRepairableRBD` and a
  `RepairableRBD` on the same layout. Honours the existing
  `working_nodes`/`broken_nodes` conditioning.
- **`parameter_sensitivity(t)`** on `NonRepairableRBD`. Reports how much system
  reliability moves per unit change in each node's distribution parameters:
  `dR_sys/dθ = birnbaum_importance(node) × d·sf_node/dθ`. The parameter
  derivative is taken numerically by rebuilding the distribution with a
  perturbed parameter via surpyval's `from_params` (a central difference,
  falling back to one-sided at a parameter bound), so it applies to any
  parametric model without per-distribution formulae. Composite and
  non-parametric nodes are omitted; a forced node is pinned regardless of its
  parameters and reports zero.
- A `parametric_spec()` helper in `_model_utils.py` centralises the
  `(class, params, param_names)` introspection used to reconstruct a node's
  distribution.

## Type of change

- [x] New feature
- [x] Documentation

## Checklist

- [x] Tests added/updated (asserting against a reference value where possible)
- [x] `black`, `isort`, `flake8`, and `mypy` pass
- [x] `coverage run -m pytest` passes and stays above the coverage gate (319 passed, 91%)
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Any Monte-Carlo tests are seeded (deterministic) — N/A, both methods are analytic/finite-difference

## Notes for reviewers

- Structural values are hand-worked in the tests: series-n and parallel-n give
  `0.5^(n-1)`; "1 in series with 2∥3" gives `{1: 0.75, 2: 0.25, 3: 0.25}`; a
  2oo3-with-valve gives `{components: 0.25, valve: 0.5}`.
- Parameter derivatives are checked to ~1e-8 against closed forms for Weibull
  (α, β), Exponential, and FixedEventProbability (where the result reduces to
  −Birnbaum, since `sf = 1 − p`).
- The one-sided fallback in `_dsf_dparam` exists so a fitted parameter sitting
  at a bound (e.g. a fixed probability near 1) yields a valid derivative
  instead of raising from inside surpyval; a boundary test covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUGaeQXKxjjiQ1ULT1ApXS

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUGaeQXKxjjiQ1ULT1ApXS)_