### PR TITLE
Condition-based evaluation (#36), doctest examples (#34), and expanded docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   nodes raise if given a state. State is transient input — the structure still
   persists via serialisation.
 
+### Documentation
+- **Doctest-backed examples** on the primary public methods (`sf`/`ff`, the
+  importance measures, `time_to_reliability`/`bx_life`, the condition-based
+  methods, `mean_availability`, and serialisation). They run in CI via
+  `--doctest-modules`, so the documented examples cannot silently rot. Examples
+  use deterministic (non-simulated) quantities so they need no seeding.
+- **Expanded documentation site**: a start-to-finish
+  [Tutorial](https://derrynknife.github.io/RePyability/tutorial/) and a
+  [Concepts](https://derrynknife.github.io/RePyability/concepts/) reference
+  (path/cut sets, exact computation, choosing an importance measure, and
+  condition-based conditioning).
+
 ## [0.5.1] - 2026-07-18
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   parameter derivative is computed numerically (via surpyval's `from_params`),
   so it applies to any parametric model without per-distribution formulae.
   Composite and non-parametric nodes are omitted; forced nodes report zero.
+- **Condition-based ("digital twin") evaluation** on `NonRepairableRBD`, driven
+  by a new public `NodeState(age, alive)` per node. Each component conditions on
+  its own current life `R_i(x | X_i) = R_i(X_i + x) / R_i(X_i)` and that
+  propagates exactly through the system:
+  - `sf_given_state(x, state)` — system reliability a further `x` from now given
+    each node's state (the conditional generalisation of `sf`; an empty state
+    reproduces `sf`).
+  - `remaining_life(target, state)` — remaining useful life (RUL): the further
+    time until system reliability falls to `target`.
+  - `importances_given_state(x, state)` — the Birnbaum and criticality
+    importances re-evaluated at the conditioned reliabilities.
+
+  Supports ordinary distribution components; dynamic (standby) and composite
+  nodes raise if given a state. State is transient input — the structure still
+  persists via serialisation.
 
 ## [0.5.1] - 2026-07-18
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -25,6 +25,8 @@ the top-level `repyability` package).
 
 ## Helpers
 
+::: repyability.NodeState
+
 ::: repyability.PerfectReliability
 
 ::: repyability.PerfectUnreliability

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,0 +1,125 @@
+# Concepts
+
+The reference behind the numbers: what an RBD means, how the system quantities
+are computed, and how to choose among the importance measures. The
+[tutorial](tutorial.md) shows these in action; this page explains them.
+
+## Reliability block diagrams
+
+A **reliability block diagram** models a system as a directed graph from a
+single input (source) to a single output (sink). Each intermediate node is a
+component with a reliability model. The system **works** at time `t` if there is
+a path of working components from input to output.
+
+Two structures underlie everything:
+
+- A **minimal path set** is a minimal set of components whose simultaneous
+  working guarantees the system works. The system is up iff *at least one* path
+  set is fully up.
+- A **minimal cut set** is a minimal set of components whose simultaneous
+  failure guarantees the system fails. The system is down iff *at least one* cut
+  set is fully down.
+
+```python
+rbd.get_min_path_sets(include_in_out_nodes=False)
+rbd.get_min_cut_sets()
+```
+
+Series, parallel, and *k*-out-of-*n* are just special cases: a series system is
+one path set of every component (and each component its own cut set); a parallel
+system is the reverse.
+
+### How the system quantity is computed
+
+Given each node's reliability, the system reliability is computed **exactly**,
+not by simulation. RePyability evaluates the probability that at least one path
+set is satisfied (or, equivalently with `method="c"`, that no cut set is), using
+a pivotal (Shannon) decomposition with memoisation so repeated substructure is
+not recomputed. The two methods return the same value; the path-set method is
+the default because it avoids deriving the cut sets.
+
+The identity that drives the decomposition — and the importance measures — is
+**pivotal decomposition** around any node *A*:
+
+```
+R_sys = R_A · R_sys(A working) + (1 − R_A) · R_sys(A failed)
+```
+
+Nodes whose reliability is only available by simulation (a standby arrangement)
+make the *system* non-analytic; those quantities fall back to Monte-Carlo (and
+take a `seed`).
+
+## Reliability vs availability
+
+- **Reliability** `R(t)` — the probability the system has *never* failed by `t`.
+  The right question for a mission or a non-repairable item. Lives on
+  [`NonRepairableRBD`][repyability.NonRepairableRBD].
+- **Availability** `A(t)` — the probability the system is *up at* `t`, allowing
+  for repair. The right question for a serviced, long-running system. Lives on
+  [`RepairableRBD`][repyability.RepairableRBD], which needs a repairability
+  distribution per component. Long-run availability is closed-form
+  (`mean_availability`); the time-resolved curve comes from a seeded
+  discrete-event simulation (`availability`).
+
+## Importance measures — which one, and why
+
+An importance measure ranks components by *how much they matter* — but "matter"
+has several meanings, and they disagree on purpose. All are available at time(s)
+`t` and accept `working_nodes`/`broken_nodes` conditioning.
+
+| Measure | Answers | Reach for it when |
+|---|---|---|
+| **Birnbaum** `birnbaum_importance` | How much does system reliability move per unit change in this node's reliability? (`∂R_sys/∂R_i`) | Ranking where a reliability improvement pays off most *right now*. |
+| **Improvement potential** `improvement_potential` | How much system reliability could I gain by making this node perfect? (`R_sys(1_i) − R_sys`) | Bounding the upside of fixing one component. |
+| **Risk achievement worth** `risk_achievement_worth` | How much worse does system *un*reliability get if this node fails? (`Q_sys(0_i)/Q_sys`) | Finding components you must *keep working* — surveillance/protection targets. |
+| **Risk reduction worth** `risk_reduction_worth` | How much would perfecting this node reduce system unreliability? (`Q_sys/Q_sys(1_i)`) | Prioritising which single fix removes the most risk. |
+| **Criticality** `criticality_importance` | Weighs Birnbaum by the node's own reliability relative to the system. | Ranking that accounts for how reliable each node already is, not just its structural leverage. |
+| **Fussell–Vesely** `fussell_vesely` | What fraction of system-failure probability involves this node? | A cut-set-based culprit ranking; standard in PRA/PSA. |
+
+Two more measures answer *design-time* and *data-targeting* questions rather
+than ranking at an operating point:
+
+- **Structural importance** `structural_importance` — Birnbaum with every node
+  reliability set to ½. It is **model-free**: it depends only on the diagram, so
+  you can rank redundancy needs *before any data exists*. Being purely
+  structural, it is identical for a `NonRepairableRBD` and a `RepairableRBD` on
+  the same layout.
+- **Parameter sensitivity** `parameter_sensitivity` — the derivative of system
+  reliability with respect to each node's *distribution parameters*
+  (`∂R_sys/∂θ = birnbaum_i · ∂sf_i/∂θ`), computed numerically. Where Birnbaum
+  says *which component* matters, this says *which fitted parameter* matters —
+  so you know where more data would most change the answer.
+
+A rule of thumb: **Birnbaum** for "where does an improvement help most",
+**risk achievement worth** for "what must not be allowed to fail",
+**structural importance** at the whiteboard, and **parameter sensitivity** when
+deciding where to spend a testing budget.
+
+## Condition-based evaluation
+
+The measures above assume every component is new. The condition-based methods
+instead take each component's *current life* `Xᵢ` and condition on it:
+
+```
+Rᵢ(x | Xᵢ) = Rᵢ(Xᵢ + x) / Rᵢ(Xᵢ)
+```
+
+This is the survival of a further `x` given the component has already reached
+`Xᵢ`. Feeding the conditioned per-node reliabilities through the same exact
+system computation gives `sf_given_state`; inverting it gives `remaining_life`
+(remaining useful life); and evaluating the importance measures at the
+conditioned reliabilities gives `importances_given_state`.
+
+Because the structure is static and only the state changes, each sensor update
+is a cheap, exact re-evaluation — the heterogeneous generalisation of the
+`cs` (conditional survival) method, which conditions the *whole system* on one
+age, to *per-component* ages. Only lifetime (time-varying) distributions age; a
+fixed-probability component's reliability does not depend on `Xᵢ`.
+
+## Scope
+
+- **Fitting failure data to distributions lives in
+  [surpyval](https://github.com/derrynknife/SurPyval), not here.** RePyability
+  consumes fitted models (anything exposing `sf`/`ff`) as node inputs.
+- **Plotting and dashboards live in the Reliafy app, not here.** RePyability is
+  the computational engine; it returns numbers and typed result objects.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -145,6 +145,51 @@ parameters to perturb and are omitted; a node forced via
 reports zero. As elsewhere, a scalar `t` returns floats and an array returns
 numpy arrays.
 
+## Condition-based reliability (a "digital twin")
+
+The methods above assume every component is brand new. In a condition-based
+setting each component instead has a *current state* — how much life it has
+already accumulated (from sensors/telemetry), and whether it is still working —
+and each conditions on its own state:
+
+```
+R_i(x | X_i)     = R_i(X_i + x) / R_i(X_i)
+R_sys(x | {X_i}) = system reliability of the conditioned components
+```
+
+You pass the state as a dict of [`NodeState`][repyability.NodeState] (a node
+omitted from the dict is treated as new):
+
+```python
+from repyability import NodeState
+
+state = {
+    "pump1": NodeState(age=1200),           # 1200 hours into life
+    "pump2": NodeState(age=800),
+    "valve": NodeState(alive=False),        # already failed
+}
+
+rbd.sf_given_state(x, state)          # reliability a further x from now
+rbd.remaining_life(0.9, state)        # remaining useful life (RUL) to R=0.9
+rbd.importances_given_state(x, state) # {"birnbaum": {...}, "criticality": {...}}
+```
+
+- `sf_given_state(x, state)` is the conditional generalisation of `sf` — with an
+  empty state it is exactly `sf(x)`, and at `x=0` it is 1 (nothing has failed
+  yet).
+- `remaining_life(target, state)` is the state-conditioned inverse: the further
+  time until system reliability falls to `target`. As redundancy is worn down,
+  RUL collapses toward the weakest surviving path.
+- `importances_given_state(x, state)` re-evaluates the Birnbaum and criticality
+  importances at the conditioned reliabilities, so the ranking reflects the
+  current wear rather than the as-new design.
+
+Only lifetime (time-varying) distributions age; a fixed-probability component
+conditioned on being alive contributes reliability 1 going forward. This
+release supports ordinary distribution components — dynamic nodes (standby) and
+composite nodes raise if given a state. The structure is static (persist it via
+serialisation); state is transient input you supply per evaluation.
+
 ## Repairable systems and availability
 
 A [`RepairableRBD`][repyability.RepairableRBD] takes components with both a

--- a/docs/index.md
+++ b/docs/index.md
@@ -104,6 +104,10 @@ rbd.mean_availability()
 
 ## Where to next
 
+- **[Tutorial](tutorial.md)** — a start-to-finish worked example: model a
+  system, find its weak link, and read its remaining life from live state.
 - **[User guide](guide.md)** — building RBDs, reliability, importance measures,
-  forcing nodes, and availability results.
+  forcing nodes, condition-based evaluation, and availability results.
+- **[Concepts](concepts.md)** — the theory: path/cut sets, choosing an
+  importance measure, and how conditioning works.
 - **[API reference](api.md)** — every public class and method.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,0 +1,236 @@
+# Tutorial: from a system to a decision
+
+This walkthrough takes a small but realistic system and answers the questions a
+reliability engineer actually asks of it — *how reliable is it, when should we
+service it, what is the weak link, and what does its remaining life look like
+once it is in the field.* Every capability in RePyability shows up here in the
+order you would reach for it.
+
+We will model a **pumping skid**:
+
+```text
+                ┌── pump1 ──┐            ┌── filterA ──┐
+   inlet ───────┤           ├── ctrl ───┤             ├─────── outlet
+                └── pump2 ──┘            └── filterB ──┘
+```
+
+Two redundant pumps feed a single controller, which feeds two redundant
+filters. The pumps and filters are each a parallel pair (either one carries the
+duty), but the controller stands alone — a **single point of failure**. Keep an
+eye on it; the analysis will keep pointing back to it.
+
+## 1. Get the component models
+
+RePyability consumes *already-fitted* lifetime models. Fitting failure data to a
+distribution is [surpyval](https://github.com/derrynknife/SurPyval)'s job — you
+would normally do:
+
+```python
+import surpyval as surv
+
+# From observed failure/censoring data (illustrative):
+pump_model = surv.Weibull.fit(failures=pump_hours, censored=still_running)
+```
+
+Here we will just assume the fits have been done and write the parameters
+directly. Times are in operating hours.
+
+```python
+import surpyval as surv
+
+reliabilities = {
+    "pump1":   surv.Weibull.from_params([12000, 1.8]),
+    "pump2":   surv.Weibull.from_params([12000, 1.8]),
+    "ctrl":    surv.Weibull.from_params([40000, 1.2]),
+    "filterA": surv.Weibull.from_params([9000, 2.5]),
+    "filterB": surv.Weibull.from_params([9000, 2.5]),
+}
+```
+
+The controller has a long characteristic life (`α = 40000`) but the filters wear
+in fast once they are near their life (`β = 2.5`).
+
+## 2. Build the RBD
+
+An RBD is its **edges** (a directed graph from one input to one output) plus a
+model per intermediate node. The input/output nodes are inferred as the unique
+source and sink.
+
+```python
+from repyability import NonRepairableRBD
+
+edges = [
+    ("inlet", "pump1"), ("inlet", "pump2"),
+    ("pump1", "ctrl"),  ("pump2", "ctrl"),
+    ("ctrl", "filterA"), ("ctrl", "filterB"),
+    ("filterA", "outlet"), ("filterB", "outlet"),
+]
+rbd = NonRepairableRBD(edges, reliabilities)
+```
+
+## 3. How reliable is it?
+
+```python
+rbd.sf(4000)      # -> 0.9091   reliability at 4000 h
+rbd.ff(4000)      # -> 0.0909   the complement, unreliability
+rbd.sf([2000, 4000, 8000])      # an array in, an array out
+```
+
+A scalar time returns a float; an array returns a numpy array. Reliability is
+computed **exactly** (not by simulation) via a memoised decomposition over the
+diagram, so these calls are cheap and repeatable.
+
+Mean time to failure is a simulated quantity — seed it for reproducibility:
+
+```python
+rbd.mean_time_to_failure(seed=0)   # ~ 8250 h (Monte-Carlo)
+```
+
+## 4. When should we service it?
+
+Invert the reliability to turn a target into a time:
+
+```python
+rbd.time_to_reliability(0.95)   # -> 2884 h  until reliability falls to 0.95
+rbd.bx_life(10)                 # -> 4188 h  the B10 life (10% failed)
+```
+
+If you want the 95%-reliability interval as a maintenance trigger, service the
+skid by ~2900 h.
+
+## 5. What is the weak link?
+
+Two questions, two tools.
+
+**At design time, before you trust any data**, use structural importance — it
+sets every component reliability to ½ and measures how often each node is
+pivotal, so it depends only on the diagram:
+
+```python
+rbd.structural_importance()
+# -> {'ctrl': 0.562, 'pump1': 0.188, 'pump2': 0.188,
+#     'filterA': 0.188, 'filterB': 0.188}
+```
+
+The controller scores **3× its neighbours** purely because it is unredundant.
+
+**With the models in hand**, use Birnbaum importance — how much a small change in
+each node's reliability moves the system:
+
+```python
+rbd.birnbaum_importance(4000)
+# -> {'ctrl': 0.968, 'pump1': 0.120, 'pump2': 0.120,
+#     'filterA': 0.114, 'filterB': 0.114}
+```
+
+Same verdict, sharper: at 4000 h the system's reliability is almost entirely
+hostage to the controller. If you are going to add redundancy anywhere, add it
+there.
+
+## 6. Which measurement should we invest in?
+
+Suppose you can afford to pin down *one* fitted parameter with more data. Which
+one most changes the answer? Parameter sensitivity chains the Birnbaum
+importance with each parameter's effect on its node:
+
+```python
+rbd.parameter_sensitivity(4000)["ctrl"]
+# -> {'alpha': 2e-06, 'beta': 0.132}
+```
+
+The controller's **shape** `β` dwarfs its scale `α`: system reliability barely
+moves with the controller's characteristic life but is sensitive to *how* its
+hazard grows. Spend the test budget resolving the shape.
+
+## 7. Going live: a condition-based "digital twin"
+
+Everything above assumed brand-new components. In service, each unit has run for
+a while and telemetry tells you how long. Feed that in and every answer
+re-computes for *this* skid, not the fleet average.
+
+Say pump1 is well-worn, pump2 is nearly new, and the controller has a lot of
+hours on it:
+
+```python
+from repyability import NodeState
+
+state = {
+    "pump1": NodeState(age=9000),
+    "pump2": NodeState(age=1000),
+    "ctrl":  NodeState(age=30000),
+}
+
+rbd.sf_given_state(2000, state)   # -> 0.9293  reliability of the next 2000 h
+rbd.sf(2000)                      # -> 0.9709  what a new skid would give
+```
+
+The remaining useful life to a 0.9 reliability target has dropped by more than a
+third against a fresh skid:
+
+```python
+rbd.remaining_life(0.9, state)    # -> 2603 h
+rbd.remaining_life(0.9, {})       # -> 4188 h  (fresh)
+```
+
+And the *live* importance ranking has shifted — with pump1 worn, the system now
+leans on the healthy pump2:
+
+```python
+rbd.importances_given_state(2000, state)["birnbaum"]
+# -> {'ctrl': 0.984, 'pump2': 0.216, 'pump1': 0.065, ...}
+```
+
+Stream a new `state` each time fresh readings arrive; every update is a cheap,
+exact re-evaluation. (Only lifetime distributions age; standby/composite nodes
+are out of scope for the condition-based methods in this release.)
+
+## 8. If the skid is repairable: availability
+
+If a failed component is repaired rather than replaced, give each one a
+*repairability* (time-to-repair) distribution and ask about availability instead
+of reliability.
+
+```python
+import surpyval as surv
+from repyability import RepairableRBD
+
+components = {
+    "pump1": {
+        "reliability":   surv.Weibull.from_params([12000, 1.8]),
+        "repairability": surv.Exponential.from_params([1 / 48]),  # ~48 h MTTR
+    },
+    # ... same for the other components ...
+}
+rep = RepairableRBD(edges, components)
+
+rep.mean_availability()                       # closed-form long-run availability
+result = rep.availability(t_simulation=20000, N=10_000, seed=0)
+result.availability                           # availability at each event time
+```
+
+Long-run availability is exact and needs no simulation; the time-resolved
+availability curve and its criticality measures come from a seeded
+discrete-event simulation.
+
+## 9. Persist the model
+
+The structure and its fitted models round-trip to plain JSON, so you can build
+the RBD once and reload it wherever the analysis runs (a dashboard, a scheduled
+job, a notebook):
+
+```python
+rbd.to_json()                       # -> a JSON string
+NonRepairableRBD.from_json(saved)   # reconstruct it
+```
+
+Node state is *not* serialised — the structure is the durable asset; state is
+transient input you supply at evaluation time.
+
+## Where to next
+
+- **[Concepts](concepts.md)** — the theory behind these numbers: path/cut sets,
+  the full importance-measure family and when to use each, and how conditioning
+  works.
+- **[User guide](guide.md)** — the reference for every method, argument, and
+  return contract.
+- **[API reference](api.md)** — the generated signatures and docstrings.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,5 +51,7 @@ markdown_extensions:
 
 nav:
   - Home: index.md
+  - Tutorial: tutorial.md
   - User guide: guide.md
+  - Concepts: concepts.md
   - API reference: api.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,13 @@ Documentation = "https://derrynknife.github.io/RePyability/"
 Repository = "https://github.com/derrynknife/RePyability"
 Issues = "https://github.com/derrynknife/RePyability/issues"
 
+[tool.pytest.ini_options]
+# Collect the unit tests and, via --doctest-modules, the runnable examples in
+# the library's docstrings, so the documented examples are exercised in CI and
+# cannot silently rot.
+testpaths = ["repyability"]
+addopts = "--doctest-modules"
+
 [tool.setuptools.dynamic]
 version = { attr = "repyability._version.__version__" }
 

--- a/repyability/__init__.py
+++ b/repyability/__init__.py
@@ -13,6 +13,7 @@ from repyability.rbd.helper_classes import (
     PerfectReliability,
     PerfectUnreliability,
 )
+from repyability.rbd.node_state import NodeState
 from repyability.rbd.non_repairable_rbd import NonRepairableRBD
 from repyability.rbd.rbd import RBD
 from repyability.rbd.repairable_rbd import RepairableRBD
@@ -44,6 +45,7 @@ __all__ = [
     # Helpers
     "PerfectReliability",
     "PerfectUnreliability",
+    "NodeState",
     # Result types
     "AvailabilityResult",
     "ConfidenceInterval",

--- a/repyability/rbd/node_state.py
+++ b/repyability/rbd/node_state.py
@@ -1,0 +1,49 @@
+"""The per-node condition input for condition-based ("digital twin")
+reliability evaluation.
+
+An RBD's *structure* is static, but in a condition-based setting each component
+has a *current state* streamed from sensors -- how much life it has already
+accumulated, and whether it is still working. :class:`NodeState` carries that
+per-node state into
+:meth:`~repyability.NonRepairableRBD.sf_given_state`,
+:meth:`~repyability.NonRepairableRBD.remaining_life` and
+:meth:`~repyability.NonRepairableRBD.importances_given_state`.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class NodeState:
+    """The current condition of a single RBD node.
+
+    A component's forward reliability is conditioned on the life it has already
+    survived: ``R_i(x | age) = R_i(age + x) / R_i(age)``. A failed component
+    (``alive=False``) contributes zero reliability regardless of its age.
+
+    Parameters
+    ----------
+    age : float, optional
+        The component's current age / accumulated exposure ``X_i`` (``>= 0``),
+        by default ``0.0`` (a brand-new component, equivalent to no
+        conditioning).
+    alive : bool, optional
+        Whether the component is currently working, by default ``True``.
+
+    Notes
+    -----
+    Only lifetime (time-varying) distributions age; a fixed-probability
+    component's reliability does not depend on ``age``. Load/stress is not part
+    of the state in this release -- it is a planned extension (accelerated-life
+    exposure and load sharing), at which point this class gains a further
+    field.
+    """
+
+    age: float = 0.0
+    alive: bool = True
+
+    def __post_init__(self) -> None:
+        if self.age < 0:
+            raise ValueError(
+                f"NodeState.age must be non-negative, got {self.age!r}."
+            )

--- a/repyability/rbd/non_repairable_rbd.py
+++ b/repyability/rbd/non_repairable_rbd.py
@@ -26,6 +26,7 @@ from repyability.utils.wrappers import conditional_survival, numpy_seed
 
 from ._model_utils import is_fixed_probability, parametric_spec
 from .helper_classes import PerfectReliability, PerfectUnreliability
+from .node_state import NodeState
 from .rbd import RBD
 from .repeated_node import RepeatedNode
 from .repeated_standby_node import RepeatedStandbyNode
@@ -733,15 +734,32 @@ class NonRepairableRBD(RBD):
             (reliability is constant in time), or if ``target`` exceeds the
             system reliability at ``t = 0`` (so it is never reached).
         """
+        return self._invert_reliability(
+            lambda t: float(self.sf(t, **kwargs)), target, upper_bound
+        )
+
+    def _invert_reliability(
+        self,
+        sf_func,
+        target: float,
+        upper_bound: Optional[float] = None,
+    ) -> float:
+        """Solve ``sf_func(t) == target`` for ``t >= 0``.
+
+        ``sf_func`` maps a scalar time to a scalar system reliability and is
+        monotonically non-increasing, so the solution is unique. Shared by
+        :meth:`time_to_reliability` and :meth:`remaining_life`; the target is
+        bracketed automatically (by doubling) unless ``upper_bound`` is given.
+        """
         if not 0.0 < target < 1.0:
             raise ValueError("target reliability must be in (0, 1).")
         if self.is_fixed:
             raise ValueError(
                 "System reliability does not vary with time (all nodes are "
-                "fixed-probability); time_to_reliability is undefined."
+                "fixed-probability); the time to a reliability is undefined."
             )
 
-        r0 = float(self.sf(0.0, **kwargs))
+        r0 = float(sf_func(0.0))
         if target > r0:
             raise ValueError(
                 f"target reliability {target} exceeds the system reliability "
@@ -749,7 +767,7 @@ class NonRepairableRBD(RBD):
             )
 
         def f(t):
-            return float(self.sf(t, **kwargs)) - target
+            return float(sf_func(t)) - target
 
         hi = upper_bound
         if hi is None:
@@ -782,6 +800,228 @@ class NonRepairableRBD(RBD):
         if not 0.0 < x < 100.0:
             raise ValueError("x must be a percentage in (0, 100).")
         return self.time_to_reliability(1.0 - x / 100.0, **kwargs)
+
+    # -- Condition-based ("digital twin") evaluation -----------------------
+
+    def _node_is_stateable(self, model) -> bool:
+        """True if a single scalar age applies unambiguously to ``model``.
+
+        Excludes the composite / dynamic node models -- a standby arrangement,
+        a repeated node, and a nested RBD -- whose conditioning semantics are
+        out of scope for condition-based evaluation in this release.
+        """
+        return not isinstance(
+            model, (StandbyModel, RepeatedStandbyNode, RepeatedNode, RBD)
+        )
+
+    def _validate_state(self, state) -> None:
+        """Validate a condition-based ``state`` mapping.
+
+        Raises rather than silently ignoring bad input: a non-mapping, a value
+        that is not a :class:`NodeState`, the input/output node, an unknown
+        node, or a node whose model is composite/dynamic.
+        """
+        if not isinstance(state, dict):
+            raise TypeError(
+                "state must be a dict of {node: NodeState}, got "
+                f"{type(state).__name__}."
+            )
+        valid = set(self.nodes)
+        for node, node_state in state.items():
+            if not isinstance(node_state, NodeState):
+                raise TypeError(
+                    f"state[{node!r}] must be a NodeState, got "
+                    f"{type(node_state).__name__}."
+                )
+            if node in self.in_or_out:
+                which = "input" if node == self.input_node else "output"
+                raise ValueError(
+                    f"Cannot set state for the {which} node {node!r}."
+                )
+            if node not in valid:
+                raise ValueError(
+                    f"Unknown node {node!r} in state; it is not a node of "
+                    "this RBD."
+                )
+            if not self._node_is_stateable(self.reliabilities[node]):
+                raise ValueError(
+                    "Condition-based evaluation supports only ordinary "
+                    f"distribution components in this release; node {node!r} "
+                    f"is a {type(self.reliabilities[node]).__name__}."
+                )
+
+    def _state_node_probabilities(self, x, state) -> Dict[Any, np.ndarray]:
+        """Per-node forward reliability at ``x`` given each node's ``state``.
+
+        ``x`` is a 1-d array. Each node conditions on its own current life: a
+        node absent from ``state`` uses its unconditioned reliability (age 0),
+        a failed node contributes zero, and an alive node of age ``X``
+        contributes ``conditional_survival(model, x, X) = sf(X + x) / sf(X)``.
+        """
+        self._validate_state(state)
+        node_probabilities: Dict[Any, np.ndarray] = {}
+        for node_name, model in self.reliabilities.items():
+            node_state = state.get(node_name)
+            if node_state is None:
+                node_probabilities[node_name] = np.atleast_1d(model.sf(x))
+            elif not node_state.alive:
+                node_probabilities[node_name] = np.atleast_1d(
+                    PerfectUnreliability.sf(x)
+                )
+            else:
+                node_probabilities[node_name] = np.atleast_1d(
+                    conditional_survival(model, x, node_state.age)
+                )
+        return node_probabilities
+
+    @check_x
+    def sf_given_state(
+        self,
+        x: Optional[ArrayLike] = None,
+        state: Optional[Dict[Hashable, NodeState]] = None,
+        method: str = "p",
+    ) -> Union[float, np.ndarray]:
+        """System reliability a further ``x`` into the future, given each
+        node's current state.
+
+        The condition-based ("digital twin") generalisation of :meth:`sf`:
+        instead of assuming every component is new, each component conditions
+        on its own current life ``X_i`` (streamed from sensors) and the
+        conditioned per-node reliabilities are propagated exactly through the
+        system::
+
+            R_i(x | X_i)     = R_i(X_i + x) / R_i(X_i)
+            R_sys(x | {X_i}) = system_probability({ R_i(x | X_i) })
+
+        Parameters
+        ----------
+        x : ArrayLike
+            The further duration/s at which reliability is evaluated (measured
+            from *now*, so ``x = 0`` is the present).
+        state : dict[Hashable, NodeState]
+            The current state of each component. A node omitted from the
+            mapping is treated as new (age 0), so an empty state reproduces
+            :meth:`sf`.
+        method : str, optional
+            "p" (path-set, default) or "c" (cut-set); both are exact.
+
+        Returns
+        -------
+        float or np.ndarray
+            System reliability given the state: a float for scalar ``x``, an
+            array for array ``x``.
+
+        Notes
+        -----
+        Only lifetime (time-varying) distributions age; a fixed-probability
+        component conditioned on being alive contributes reliability 1 going
+        forward (its per-demand uncertainty is resolved by observing it
+        alive). Composite / dynamic nodes (standby, repeated, nested RBD) are
+        not supported here in this release and raise if given a state.
+        """
+        if state is None:
+            state = {}
+        node_probabilities = self._state_node_probabilities(x, state)
+        return self.system_probability(node_probabilities, method=method)
+
+    def remaining_life(
+        self,
+        target: float,
+        state: Optional[Dict[Hashable, NodeState]] = None,
+        upper_bound: Optional[float] = None,
+    ) -> float:
+        """Remaining useful life (RUL): the further time until system
+        reliability falls to ``target``, given each node's current state.
+
+        The condition-based analogue of :meth:`time_to_reliability`: it solves
+        ``sf_given_state(t, state) == target`` for ``t``. Because
+        ``sf_given_state`` is measured from now, the result is the time
+        *remaining* from the current state. ``remaining_life(1 - x/100,
+        state)`` is the conditional B\\ :sub:`X` life.
+
+        Parameters
+        ----------
+        target : float
+            The system reliability level to solve for, in (0, 1).
+        state : dict[Hashable, NodeState]
+            The current state of each component (see :meth:`sf_given_state`).
+        upper_bound : float, optional
+            An upper bound for the search; found automatically if None.
+
+        Returns
+        -------
+        float
+            The remaining time until ``R_sys(t | state) == target``.
+        """
+        if state is None:
+            state = {}
+        return self._invert_reliability(
+            lambda t: float(self.sf_given_state(t, state)),
+            target,
+            upper_bound,
+        )
+
+    def importances_given_state(
+        self,
+        x: Optional[ArrayLike] = None,
+        state: Optional[Dict[Hashable, NodeState]] = None,
+    ) -> Dict[str, Dict[Any, Union[float, np.ndarray]]]:
+        """Live, state-dependent node importance over a forward horizon ``x``
+        -- how each component's importance shifts once the current wear on
+        every component is accounted for.
+
+        Evaluates the Birnbaum and criticality importance measures at the
+        conditioned per-node reliabilities ``R_i(x | X_i)`` (see
+        :meth:`sf_given_state`) rather than at the as-new reliabilities, so the
+        rankings reflect the current state. Both use the same conventions as
+        :meth:`birnbaum_importance` and :meth:`criticality_importance`: they
+        measure how much the system reliability depends on each node *now*, not
+        which node is most likely to have failed.
+
+        Parameters
+        ----------
+        x : ArrayLike
+            The forward horizon/s over which importance is evaluated (from
+            now).
+        state : dict[Hashable, NodeState]
+            The current state of each component (see :meth:`sf_given_state`).
+
+        Returns
+        -------
+        dict[str, dict[Any, float | np.ndarray]]
+            ``{"birnbaum": {node: value}, "criticality": {node: value}}``.
+            Values are floats for scalar ``x`` and arrays for array ``x``.
+        """
+        if state is None:
+            state = {}
+        if x is None:
+            if self.is_fixed:
+                x = 1.0
+            else:
+                raise ValueError(
+                    "x is required: this RBD is time-varying (at least one "
+                    "node model's probability depends on time)."
+                )
+        scalar_in = np.ndim(x) == 0
+        x_arr = np.atleast_1d(np.asarray(x, dtype=float))
+        node_probabilities = self._state_node_probabilities(x_arr, state)
+        birnbaum = super()._birnbaum_importance(node_probabilities)
+        criticality = super()._criticality_importance(node_probabilities)
+
+        def _squeeze(measure):
+            return {
+                node: (
+                    float(np.asarray(value).reshape(-1)[0])
+                    if scalar_in
+                    else np.asarray(value)
+                )
+                for node, value in measure.items()
+            }
+
+        return {
+            "birnbaum": _squeeze(birnbaum),
+            "criticality": _squeeze(criticality),
+        }
 
     def node_mttf(
         self, mc_samples: int = 100_000, seed=None

--- a/repyability/rbd/non_repairable_rbd.py
+++ b/repyability/rbd/non_repairable_rbd.py
@@ -323,6 +323,28 @@ class NonRepairableRBD(RBD):
         ValueError
             If a working/broken node is unknown, is the input/output node, is
             in both sets, or is a repeat of another node.
+
+        Examples
+        --------
+        Two components in parallel, each 90% reliable, so the system is
+        ``1 - 0.1 * 0.1 = 0.99`` reliable:
+
+        >>> from surpyval import FixedEventProbability
+        >>> from repyability import NonRepairableRBD
+        >>> rbd = NonRepairableRBD(
+        ...     [("s", "a"), ("s", "b"), ("a", "t"), ("b", "t")],
+        ...     {
+        ...         "a": FixedEventProbability.from_params(0.1),
+        ...         "b": FixedEventProbability.from_params(0.1),
+        ...     },
+        ... )
+        >>> round(rbd.sf(), 4)
+        0.99
+
+        Conditioning on node ``"a"`` having failed leaves only ``"b"``:
+
+        >>> round(rbd.sf(broken_nodes=["a"]), 4)
+        0.9
         """
         # Normalise the (optional) node overrides into sets for O(1) lookup.
         working_nodes = set() if working_nodes is None else set(working_nodes)
@@ -360,6 +382,20 @@ class NonRepairableRBD(RBD):
         float or np.ndarray
             The system unreliability: a float for scalar ``x``, an array for
             array ``x``.
+
+        Examples
+        --------
+        >>> from surpyval import FixedEventProbability
+        >>> from repyability import NonRepairableRBD
+        >>> rbd = NonRepairableRBD(
+        ...     [("s", "a"), ("s", "b"), ("a", "t"), ("b", "t")],
+        ...     {
+        ...         "a": FixedEventProbability.from_params(0.1),
+        ...         "b": FixedEventProbability.from_params(0.1),
+        ...     },
+        ... )
+        >>> round(rbd.ff(), 4)
+        0.01
         """
         return 1 - self.sf(x, *args, **kwargs)
 
@@ -733,6 +769,17 @@ class NonRepairableRBD(RBD):
             If ``target`` is not in (0, 1), if the RBD is fixed-probability
             (reliability is constant in time), or if ``target`` exceeds the
             system reliability at ``t = 0`` (so it is never reached).
+
+        Examples
+        --------
+        >>> import surpyval as surv
+        >>> from repyability import NonRepairableRBD
+        >>> rbd = NonRepairableRBD(
+        ...     [("s", "c"), ("c", "t")],
+        ...     {"c": surv.Weibull.from_params([100, 2])},
+        ... )
+        >>> round(rbd.time_to_reliability(0.9), 2)
+        32.46
         """
         return self._invert_reliability(
             lambda t: float(self.sf(t, **kwargs)), target, upper_bound
@@ -796,6 +843,19 @@ class NonRepairableRBD(RBD):
             The percentage failed, in (0, 100).
         **kwargs :
             Any sf() arguments (e.g. working_nodes, broken_nodes, method).
+
+        Examples
+        --------
+        The B10 life (10% failed) of a single Weibull component:
+
+        >>> import surpyval as surv
+        >>> from repyability import NonRepairableRBD
+        >>> rbd = NonRepairableRBD(
+        ...     [("s", "c"), ("c", "t")],
+        ...     {"c": surv.Weibull.from_params([100, 2])},
+        ... )
+        >>> round(rbd.bx_life(10), 2)
+        32.46
         """
         if not 0.0 < x < 100.0:
             raise ValueError("x must be a percentage in (0, 100).")
@@ -918,6 +978,20 @@ class NonRepairableRBD(RBD):
         forward (its per-demand uncertainty is resolved by observing it
         alive). Composite / dynamic nodes (standby, repeated, nested RBD) are
         not supported here in this release and raise if given a state.
+
+        Examples
+        --------
+        A component 40 hours into life is less reliable over the next 50 than
+        a new one would be:
+
+        >>> import surpyval as surv
+        >>> from repyability import NonRepairableRBD, NodeState
+        >>> rbd = NonRepairableRBD(
+        ...     [("s", "c"), ("c", "t")],
+        ...     {"c": surv.Weibull.from_params([100, 2])},
+        ... )
+        >>> round(rbd.sf_given_state(50, {"c": NodeState(age=40)}), 4)
+        0.522
         """
         if state is None:
             state = {}
@@ -952,6 +1026,17 @@ class NonRepairableRBD(RBD):
         -------
         float
             The remaining time until ``R_sys(t | state) == target``.
+
+        Examples
+        --------
+        >>> import surpyval as surv
+        >>> from repyability import NonRepairableRBD, NodeState
+        >>> rbd = NonRepairableRBD(
+        ...     [("s", "c"), ("c", "t")],
+        ...     {"c": surv.Weibull.from_params([100, 2])},
+        ... )
+        >>> round(rbd.remaining_life(0.9, {"c": NodeState(age=40)}), 2)
+        11.51
         """
         if state is None:
             state = {}
@@ -1071,6 +1156,24 @@ class NonRepairableRBD(RBD):
         dict[Any, float | np.ndarray]
             Dictionary with node names as keys and Birnbaum importances as
             values (floats for scalar ``x``, arrays for array ``x``)
+
+        Examples
+        --------
+        In a two-component parallel system each node's Birnbaum importance is
+        the probability the *other* node has failed:
+
+        >>> from surpyval import FixedEventProbability
+        >>> from repyability import NonRepairableRBD
+        >>> rbd = NonRepairableRBD(
+        ...     [("s", "a"), ("s", "b"), ("a", "t"), ("b", "t")],
+        ...     {
+        ...         "a": FixedEventProbability.from_params(0.1),
+        ...         "b": FixedEventProbability.from_params(0.1),
+        ...     },
+        ... )
+        >>> bi = rbd.birnbaum_importance()
+        >>> {k: round(v, 4) for k, v in sorted(bi.items())}
+        {'a': 0.1, 'b': 0.1}
         """
         node_probabilities = self._probabilities_with_overrides(
             self.node_sf(x), working_nodes, broken_nodes

--- a/repyability/rbd/rbd.py
+++ b/repyability/rbd/rbd.py
@@ -658,6 +658,24 @@ class RBD:
         -------
         dict[Any, float]
             Node name -> structural importance, in ``[0, 1]``.
+
+        Examples
+        --------
+        In a two-component parallel system each node is pivotal in half of the
+        other node's states, independent of any failure model:
+
+        >>> from surpyval import FixedEventProbability
+        >>> from repyability import NonRepairableRBD
+        >>> rbd = NonRepairableRBD(
+        ...     [("s", "a"), ("s", "b"), ("a", "t"), ("b", "t")],
+        ...     {
+        ...         "a": FixedEventProbability.from_params(0.1),
+        ...         "b": FixedEventProbability.from_params(0.4),
+        ...     },
+        ... )
+        >>> si = rbd.structural_importance()
+        >>> {k: round(v, 4) for k, v in sorted(si.items())}
+        {'a': 0.5, 'b': 0.5}
         """
         node_probabilities = {node: np.full(1, 0.5) for node in self.nodes}
         node_probabilities = self._probabilities_with_overrides(
@@ -692,6 +710,21 @@ class RBD:
 
         Called on a specific subclass, the document's ``type`` must match;
         called on ``RBD`` it dispatches to whichever type the document names.
+
+        Examples
+        --------
+        The structure round-trips through a plain dict, so reliability is
+        preserved:
+
+        >>> import surpyval as surv
+        >>> from repyability import NonRepairableRBD
+        >>> rbd = NonRepairableRBD(
+        ...     [("s", "c"), ("c", "t")],
+        ...     {"c": surv.Weibull.from_params([100, 2])},
+        ... )
+        >>> restored = NonRepairableRBD.from_dict(rbd.to_dict())
+        >>> round(restored.sf(50), 4) == round(rbd.sf(50), 4)
+        True
         """
         from repyability.rbd.serialisation import rbd_from_dict
 

--- a/repyability/rbd/repairable_rbd.py
+++ b/repyability/rbd/repairable_rbd.py
@@ -314,6 +314,25 @@ class RepairableRBD(RBD):
         ValueError
             If a working/broken node is unknown, is the input/output node, or
             is in both sets.
+
+        Examples
+        --------
+        A single component with mean time to failure 10 and mean time to
+        repair 1 has long-run availability ``10 / (10 + 1)``:
+
+        >>> import surpyval as surv
+        >>> from repyability import RepairableRBD
+        >>> rbd = RepairableRBD(
+        ...     [("s", "c"), ("c", "t")],
+        ...     {
+        ...         "c": {
+        ...             "reliability": surv.Exponential.from_params([0.1]),
+        ...             "repairability": surv.Exponential.from_params([1.0]),
+        ...         }
+        ...     },
+        ... )
+        >>> round(rbd.mean_availability(), 4)
+        0.9091
         """
         # Good reference on the Availability of a system
         # https://www.diva-portal.org/smash/get/diva2:986067/FULLTEXT01.pdf

--- a/repyability/tests/test_condition_based.py
+++ b/repyability/tests/test_condition_based.py
@@ -1,0 +1,260 @@
+"""
+Tests the condition-based ("digital twin") evaluation layer:
+NodeState, sf_given_state, remaining_life and importances_given_state.
+"""
+
+import numpy as np
+import pytest
+import surpyval as surv
+
+from repyability import NodeState, NonRepairableRBD
+from repyability.rbd.standby_node import StandbyModel
+from repyability.utils.wrappers import conditional_survival
+
+
+def _weibull_series() -> NonRepairableRBD:
+    return NonRepairableRBD(
+        [(1, 2), (2, 3), (3, 4), (4, 5)],
+        {
+            2: surv.Weibull.from_params([20, 2]),
+            3: surv.Weibull.from_params([100, 3]),
+            4: surv.Weibull.from_params([50, 20]),
+        },
+    )
+
+
+def _weibull_parallel() -> NonRepairableRBD:
+    return NonRepairableRBD(
+        [(1, 2), (1, 3), (2, 4), (3, 4)],
+        {
+            2: surv.Weibull.from_params([50, 3]),
+            3: surv.Weibull.from_params([50, 3]),
+        },
+    )
+
+
+# -- NodeState ------------------------------------------------------------
+
+
+def test_nodestate_defaults():
+    ns = NodeState()
+    assert ns.age == 0.0
+    assert ns.alive is True
+
+
+def test_nodestate_is_frozen():
+    ns = NodeState(age=5)
+    with pytest.raises(Exception):
+        ns.age = 10  # type: ignore[misc]
+
+
+def test_nodestate_negative_age_raises():
+    with pytest.raises(ValueError, match="non-negative"):
+        NodeState(age=-1.0)
+
+
+# -- sf_given_state -------------------------------------------------------
+
+
+def test_empty_state_matches_sf():
+    rbd = _weibull_series()
+    assert rbd.sf_given_state(10.0, {}) == pytest.approx(rbd.sf(10.0))
+    # state omitted entirely behaves the same
+    assert rbd.sf_given_state(10.0) == pytest.approx(rbd.sf(10.0))
+
+
+def test_zero_horizon_is_one():
+    rbd = _weibull_series()
+    state = {2: NodeState(age=5), 3: NodeState(age=8)}
+    assert rbd.sf_given_state(0.0, state) == pytest.approx(1.0)
+
+
+def test_single_node_matches_conditional_survival():
+    model = surv.Weibull.from_params([20, 2])
+    rbd = NonRepairableRBD([(1, 2), (2, 3)], {2: model})
+    expected = conditional_survival(model, 10.0, 5.0)
+    assert rbd.sf_given_state(10.0, {2: NodeState(age=5)}) == pytest.approx(
+        expected
+    )
+
+
+def test_scalar_and_array_contract():
+    rbd = _weibull_series()
+    state = {2: NodeState(age=5)}
+    assert isinstance(rbd.sf_given_state(10.0, state), float)
+    out = rbd.sf_given_state(np.array([5.0, 10.0, 15.0]), state)
+    assert isinstance(out, np.ndarray)
+    assert out.shape == (3,)
+
+
+def test_aging_reduces_reliability_for_wearing_component():
+    """For an increasing-failure-rate (beta > 1) component, an aged unit is
+    less reliable over the next x than a fresh one."""
+    rbd = _weibull_series()
+    fresh = rbd.sf_given_state(10.0, {})
+    aged = rbd.sf_given_state(10.0, {2: NodeState(age=30)})
+    assert aged < fresh
+
+
+def test_failed_node_in_series_is_zero():
+    rbd = NonRepairableRBD(
+        [(1, 2), (2, 3), (3, 4)],
+        {
+            2: surv.Weibull.from_params([20, 2]),
+            3: surv.Weibull.from_params([30, 2]),
+        },
+    )
+    assert rbd.sf_given_state(
+        5.0, {2: NodeState(alive=False)}
+    ) == pytest.approx(0.0)
+
+
+def test_failed_node_in_parallel_reduces_to_survivor():
+    rbd = _weibull_parallel()
+    expected = rbd.reliabilities[3].sf(5.0)
+    assert rbd.sf_given_state(
+        5.0, {2: NodeState(alive=False)}
+    ) == pytest.approx(expected)
+
+
+def test_cut_and_path_methods_agree():
+    rbd = _weibull_parallel()
+    state = {2: NodeState(age=20)}
+    assert rbd.sf_given_state(5.0, state, method="c") == pytest.approx(
+        rbd.sf_given_state(5.0, state, method="p")
+    )
+
+
+# -- remaining_life -------------------------------------------------------
+
+
+def test_remaining_life_round_trips():
+    rbd = _weibull_parallel()
+    state = {2: NodeState(age=20)}
+    rul = rbd.remaining_life(0.9, state)
+    assert rbd.sf_given_state(rul, state) == pytest.approx(0.9)
+
+
+def test_remaining_life_collapses_as_redundancy_worn():
+    rbd = _weibull_parallel()
+    fresh = rbd.remaining_life(0.9, {})
+    one_worn = rbd.remaining_life(0.9, {2: NodeState(age=40)})
+    both_worn = rbd.remaining_life(
+        0.9, {2: NodeState(age=40), 3: NodeState(age=40)}
+    )
+    assert fresh > one_worn > both_worn
+
+
+def test_remaining_life_exponential_is_memoryless():
+    """An exponential component is memoryless, so ageing it leaves the RUL
+    unchanged (equal to the as-new time_to_reliability)."""
+    rbd = NonRepairableRBD(
+        [(1, 2), (2, 3)], {2: surv.Exponential.from_params([0.1])}
+    )
+    as_new = rbd.time_to_reliability(0.5)
+    aged = rbd.remaining_life(0.5, {2: NodeState(age=25)})
+    assert aged == pytest.approx(as_new, rel=1e-6)
+
+
+def test_remaining_life_unreachable_target_raises():
+    """A failed node in series drops reliability to 0 at t=0, so no positive
+    target is reachable."""
+    rbd = NonRepairableRBD(
+        [(1, 2), (2, 3), (3, 4)],
+        {
+            2: surv.Weibull.from_params([20, 2]),
+            3: surv.Weibull.from_params([30, 2]),
+        },
+    )
+    with pytest.raises(ValueError, match="exceeds the system reliability"):
+        rbd.remaining_life(0.5, {2: NodeState(alive=False)})
+
+
+def test_remaining_life_on_fixed_rbd_raises():
+    from surpyval import FixedEventProbability
+
+    rbd = NonRepairableRBD(
+        [(1, 2), (2, 3)],
+        {2: FixedEventProbability.from_params(1 - 0.9)},
+    )
+    with pytest.raises(ValueError, match="does not vary with time"):
+        rbd.remaining_life(0.5, {})
+
+
+# -- importances_given_state ---------------------------------------------
+
+
+def test_importances_empty_state_matches_base_measures():
+    rbd = _weibull_parallel()
+    imp = rbd.importances_given_state(5.0, {})
+    birnbaum = rbd.birnbaum_importance(5.0)
+    criticality = rbd.criticality_importance(5.0)
+    for node in birnbaum:
+        assert imp["birnbaum"][node] == pytest.approx(birnbaum[node])
+        assert imp["criticality"][node] == pytest.approx(criticality[node])
+
+
+def test_importances_structure_and_state_dependence():
+    rbd = _weibull_parallel()
+    baseline = rbd.importances_given_state(5.0, {})
+    conditioned = rbd.importances_given_state(5.0, {2: NodeState(age=40)})
+    assert set(baseline) == {"birnbaum", "criticality"}
+    assert set(baseline["birnbaum"]) == {2, 3}
+    # ageing a component shifts the importance ranking
+    assert baseline["birnbaum"][3] != pytest.approx(conditioned["birnbaum"][3])
+
+
+def test_importances_scalar_and_array_contract():
+    rbd = _weibull_parallel()
+    state = {2: NodeState(age=20)}
+    scalar = rbd.importances_given_state(5.0, state)
+    assert all(isinstance(v, float) for v in scalar["birnbaum"].values())
+    arr = rbd.importances_given_state(np.array([5.0, 10.0]), state)
+    assert all(
+        isinstance(v, np.ndarray) and v.shape == (2,)
+        for v in arr["birnbaum"].values()
+    )
+
+
+# -- validation -----------------------------------------------------------
+
+
+def test_unknown_node_in_state_raises():
+    rbd = _weibull_series()
+    with pytest.raises(ValueError, match="Unknown node"):
+        rbd.sf_given_state(5.0, {"nope": NodeState(age=1)})
+
+
+def test_state_value_must_be_nodestate():
+    rbd = _weibull_series()
+    with pytest.raises(TypeError, match="must be a NodeState"):
+        rbd.sf_given_state(5.0, {2: 5.0})
+
+
+def test_state_must_be_a_mapping():
+    rbd = _weibull_series()
+    with pytest.raises(TypeError, match="state must be a dict"):
+        rbd.sf_given_state(5.0, [NodeState(age=1)])
+
+
+def test_input_output_node_state_raises():
+    rbd = _weibull_series()
+    with pytest.raises(ValueError, match="input"):
+        rbd.sf_given_state(5.0, {1: NodeState(age=1)})
+
+
+def test_dynamic_node_state_raises():
+    rbd = NonRepairableRBD(
+        [(1, 2), (2, 3), (3, 4)],
+        {
+            2: surv.Weibull.from_params([20, 2]),
+            3: StandbyModel(
+                [
+                    surv.Weibull.from_params([5, 1.1]),
+                    surv.Weibull.from_params([5, 1.1]),
+                ]
+            ),
+        },
+    )
+    with pytest.raises(ValueError, match="ordinary distribution"):
+        rbd.sf_given_state(5.0, {3: NodeState(age=2)})


### PR DESCRIPTION
## Summary

Completes the remaining implementation work for the 0.6.0 "Condition-Based
Reliability" milestone.

**Condition-based ("digital twin") evaluation (#36)** — a new public
`NodeState(age, alive)` per node, and three methods on `NonRepairableRBD` that
condition each component on its own current life
`R_i(x | X_i) = R_i(X_i + x) / R_i(X_i)` and propagate it exactly through the
system:
- `sf_given_state(x, state)` — system reliability a further `x` from now (the
  conditional generalisation of `sf`; empty state reproduces `sf`).
- `remaining_life(target, state)` — remaining useful life (RUL). The `brentq`
  bracketing is factored out of `time_to_reliability` into a shared
  `_invert_reliability` helper.
- `importances_given_state(x, state)` — Birnbaum and criticality re-evaluated at
  the conditioned reliabilities.

Ordinary distribution components only; dynamic (standby) and composite nodes
raise if given a state. State is transient — serialisation is unchanged.

**Doctest-backed examples (#34)** — pytest is configured with
`--doctest-modules`, so the runnable `>>>` examples now added to the primary
public methods (`sf`/`ff`, the importance measures, `time_to_reliability`/
`bx_life`, the condition-based methods, `mean_availability`, and serialisation)
run in CI and cannot silently rot. Examples use deterministic quantities, so no
seeding is required.

**Expanded documentation** — a start-to-finish Tutorial and a Concepts reference
(path/cut sets, exact computation, an importance-measure decision table, and
condition-based conditioning), wired into the nav and cross-linked from the home
page.

## Type of change

- [x] New feature
- [x] Documentation
- [x] Refactor / tooling

## Checklist

- [x] Tests added/updated (asserting against a reference value where possible)
- [x] `black`, `isort`, `flake8`, and `mypy` pass
- [x] `coverage run -m pytest` passes and stays above the coverage gate (353 passed, 91%)
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Any Monte-Carlo tests are seeded (deterministic) — the condition-based methods and all doctests are analytic/closed-form

## Notes for reviewers

- `structural_importance` is inherited by both RBD types (it is defined on the
  base class); `sf_given_state`/`remaining_life`/`importances_given_state` are
  on `NonRepairableRBD`.
- The importance measures under `importances_given_state` track sensitivity /
  the load-bearing component, not "the failing one" — the docstring is worded to
  avoid implying the latter.
- The RUL-collapse behaviour the issue flagged is covered in
  `test_condition_based.py` (2-parallel: 36.2 → 25.3 → 8.1 h as branches wear),
  alongside the empty-state==`sf`, `x=0`==1, single-node vs `conditional_survival`,
  exponential-memorylessness, validation, and dynamic-node-rejection cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUGaeQXKxjjiQ1ULT1ApXS

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUGaeQXKxjjiQ1ULT1ApXS)_