### PR TITLE
Harmonise RBD constructor signatures (structure before k)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet._
+### Changed
+- **Harmonised the RBD constructor signatures.** The base ``RBD`` now takes
+  ``(edges, nodes, k, ...)`` instead of ``(edges, k, nodes, ...)``, so all
+  three classes share the same positional order: the structure first (``edges``
+  then the node definition -- ``nodes``/``reliabilities``/``components``), then
+  the optional ``k`` (k-out-of-n) modifier. ``NonRepairableRBD`` and
+  ``RepairableRBD`` are unchanged. This only affects code that constructed the
+  base ``RBD`` with a *positional* ``k`` (``RBD(edges, k_dict)``); pass ``k`` by
+  keyword (``RBD(edges, k=k_dict)``) or as the third argument.
 
 ## [0.6.0] - 2026-07-19
 

--- a/repyability/rbd/non_repairable_rbd.py
+++ b/repyability/rbd/non_repairable_rbd.py
@@ -161,8 +161,8 @@ class NonRepairableRBD(RBD):
         if repeated == {}:
             super().__init__(
                 edges,
-                k,
                 set(reliabilities.keys()),
+                k,
                 input_node,
                 output_node,
                 on_infeasible_rbd,
@@ -178,8 +178,8 @@ class NonRepairableRBD(RBD):
                 new_edges.append((start, stop))
             super().__init__(
                 new_edges,
-                k,
                 set(reliabilities.keys()),
+                k,
                 input_node,
                 output_node,
                 on_infeasible_rbd,

--- a/repyability/rbd/rbd.py
+++ b/repyability/rbd/rbd.py
@@ -214,22 +214,32 @@ class RBD:
     def __init__(
         self,
         edges: Iterable[tuple[Hashable, Hashable]],
-        k: Optional[dict[Any, int]] = None,
         nodes: Optional[Iterable] = None,
+        k: Optional[dict[Any, int]] = None,
         input_node: Optional[Any] = None,
         output_node: Optional[Any] = None,
         on_infeasible_rbd: str = "raise",
     ):
         """Creates and returns a Reliability Block Diagram object.
 
+        The positional order mirrors the subclasses
+        (:class:`~repyability.NonRepairableRBD`,
+        :class:`~repyability.RepairableRBD`): the structure -- ``edges`` then
+        ``nodes`` -- comes first, and ``k`` (k-out-of-n) is an optional
+        modifier after it.
+
         Parameters
         ----------
         edges : Iterable[tuple[Hashable, Hashable]]
             The collection of node edges, e.g. [(1, 2), (2, 3)] would
             correspond to the edges 1-2 and 2-3
-        k : dict[Any, int]
-            A dictionary mapping nodes to k-out-of-n (koon) values, by default
-            {}, by default all nodes koon values are 1
+        nodes : Iterable, optional
+            Extra node names to include beyond those implied by ``edges`` (e.g.
+            isolated nodes), by default None. The RBD subclasses pass their set
+            of component names here.
+        k : dict[Any, int], optional
+            A dictionary mapping nodes to k-out-of-n (koon) values; by default
+            every node's koon value is 1.
         on_infeasible_rbd : {{'raise', 'warn', 'ignore'}}, default 'raise'
             Specifies what to do upon encountering a bad line (a line with too
             many fields). Allowed values are :

--- a/repyability/rbd/repairable_rbd.py
+++ b/repyability/rbd/repairable_rbd.py
@@ -189,8 +189,8 @@ class RepairableRBD(RBD):
 
         super().__init__(
             edges,
-            k,
             set(components.keys()),
+            k,
             input_node,
             output_node,
             on_infeasible_rbd,


### PR DESCRIPTION
## Summary

Makes the RBD constructors consistent in their positional order.

The base `RBD` took `(edges, k, nodes, ...)` while both subclasses take
`(edges, <node models>, k, ...)`, so `k` came *before* the node definition in
the base class but *after* it in `NonRepairableRBD`/`RepairableRBD`.

This reorders the base `RBD` to `(edges, nodes, k, ...)` so all three classes
are positionally **structure-first** — `edges`, then the node definition
(`nodes` / `reliabilities` / `components`), then the optional `k` (k-out-of-n)
modifier — and updates the three internal `super().__init__` calls to match.

## Type of change

- [x] Refactor / tooling
- [x] Breaking change (minor — see below)

## Checklist

- [x] Tests added/updated — existing koon tests cover all three constructors; verified 2-out-of-3 resolves correctly via each
- [x] `black`, `isort`, `flake8`, and `mypy` pass (mypy 2.3.0)
- [x] `coverage run -m pytest` passes and stays above the coverage gate (353 passed)
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Any Monte-Carlo tests are seeded (deterministic) — N/A

## Notes for reviewers

- `NonRepairableRBD` and `RepairableRBD` signatures are **unchanged**.
- The only breaking case is constructing the base `RBD` with a *positional*
  `k` (`RBD(edges, k_dict)`) — now pass `k=` by keyword or as the third
  argument. No test or internal caller did this; serialisation already passes
  `k=` as a keyword.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUGaeQXKxjjiQ1ULT1ApXS

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUGaeQXKxjjiQ1ULT1ApXS)_