### PR TITLE
Imperfect repair (Kijima/GRP) in the Repairable component (#49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Imperfect repair (generalized renewal / Kijima) in `Repairable`.** The
+  `Repairable` component now spans the whole repair-effectiveness spectrum
+  rather than only minimal repair: it sources the expected number of failures
+  `E[N(t)]` from the model it is given — analytic `cif` for minimal repair
+  (unchanged; e.g. a surpyval Crow-AMSAA) or a seeded `mcf` for imperfect
+  repair (a fitted `GeneralizedRenewal`, Kijima I/II). Minimal repair is the
+  `q = 1` special case; perfect repair (`q = 0`) is the `NonRepairable`
+  boundary. The overhaul/replacement-interval policy is unchanged in form
+  `(cr·E[N(t)] + co)/t`; for a simulation-backed model `optimal_overhaul_policy`
+  / `find_optimal_overhaul_interval` take `seed`, `n_simulations` and
+  `max_interval` for a reproducible, bounded search, and `is_simulated` reports
+  which path a `Repairable` uses.
+
 ### Changed
 - **Harmonised the RBD constructor signatures.** The base ``RBD`` now takes
   ``(edges, nodes, k, ...)`` instead of ``(edges, k, nodes, ...)``, so all

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -289,12 +289,15 @@ two ends of the repair-effectiveness spectrum:
   failure ("as good as new"): every cycle is a statistical renewal. This is
   also the component model `RepairableRBD` uses internally, because RBD
   repairs are assumed to restore a component to as-new.
-- [`Repairable`][repyability.Repairable] — the unit is patched by **minimal
-  repair** ("as bad as old"): fixes restore function but not age, so
-  failures arrive ever faster, following a recurrent-event model (its
-  cumulative intensity `cif`, e.g. surpyval's Crow-AMSAA). Because that
-  violates the renewal assumption, `Repairable` is a standalone tool — it
-  is **not** a valid RBD node model.
+- [`Repairable`][repyability.Repairable] — the unit is patched by **repair**
+  that rejuvenates it anywhere from not at all (**minimal repair**, "as bad as
+  old") to partially (**imperfect repair** / generalized renewal), then
+  periodically **overhauled or replaced** to as-new. It prices the same policy
+  from the model's expected number of failures `E[N(t)]`: analytic `cif` for
+  minimal repair (e.g. surpyval's Crow-AMSAA) or seeded `mcf` for imperfect
+  repair (a fitted `GeneralizedRenewal`, Kijima I/II). Because a repaired unit
+  does not renew, `Repairable` is a standalone tool — it is **not** a valid RBD
+  node model.
 
 ### Age replacement (`NonRepairable`)
 
@@ -339,6 +342,36 @@ policy.interval, policy.cost_rate
 A finite optimum requires wear-out (Crow-AMSAA `beta > 1`). For HPP-like
 behaviour (`beta <= 1`) repairs never become more frequent, overhauls never
 pay, and the interval is `inf` with the cost rate of repairs alone.
+
+### Imperfect repair (`Repairable`)
+
+Real repairs sit between the extremes: each one rejuvenates the unit
+*partially* (a restoration factor `0 < q < 1` — the generalized-renewal /
+Kijima virtual-age model), so failures still accelerate, but more slowly than
+under minimal repair. Give `Repairable` a fitted surpyval `GeneralizedRenewal`
+and the *same* overhaul/replacement policy applies — only now `E[N(t)]` has no
+closed form and is estimated by simulation, so pass a `seed` for a reproducible
+result:
+
+```python
+from surpyval import Weibull
+from surpyval.recurrent import GeneralizedRenewal
+from repyability import Repairable
+
+model = GeneralizedRenewal.fit_from_parameters(
+    [1500, 2.0], q=0.4, kijima="i", dist=Weibull
+)
+unit = Repairable(model)                 # unit.is_simulated is True
+unit.set_repair_and_overhaul_costs(100, 10_000)
+
+policy = unit.optimal_overhaul_policy(seed=0)   # seeded → reproducible
+policy.interval, policy.cost_rate
+```
+
+Minimal repair is the `q = 1` edge of this model and perfect repair (`q = 0`,
+every repair a renewal) the `NonRepairable` boundary. `n_simulations` sets the
+Monte-Carlo sample size and `max_interval` the search horizon — raise it if the
+optimum (which grows as repairs get more effective) sits beyond the default.
 
 ## Saving and loading
 

--- a/repyability/repairable.py
+++ b/repyability/repairable.py
@@ -1,67 +1,103 @@
-"""Minimal-repair ("as bad as old") component economics.
+"""Repairable-component economics across the repair-effectiveness spectrum.
 
-A unit restored by *minimal repair* keeps its accumulated age through every
-fix: repairs return it to service but do not rejuvenate it, so failures
-recur with rising frequency. That failure history is a recurrent-event
-process with cumulative intensity ``Lambda(t)`` — the expected number of
-failures by age ``t`` — available from a surpyval recurrence model as
-``model.cif(t)`` (e.g. Crow-AMSAA / NHPP, Duane, HPP).
+A repaired unit is restored to service, but *how much* a repair rejuvenates it
+varies. ``Repairable`` prices the classic repair-vs-renew trade-off for a unit
+whose repairs are anything from worthless to partial:
 
-``Repairable`` prices the classic trade-off for such a unit: each minimal
-repair costs ``cr``, while an *overhaul* costs ``co`` (> ``cr``) and renews
-the unit to as-new. Overhauling every ``t`` time units makes each overhaul
-cycle a renewal cycle costing ``cr * Lambda(t) + co``, so the long-run cost
-rate is::
+- **Minimal repair** ("as bad as old") — a repair returns the unit to service
+  but removes none of its accumulated age, so failures recur with rising
+  frequency. This is a recurrent-event process with cumulative intensity
+  ``Lambda(t) = E[N(t)]`` (the expected number of failures by age ``t``),
+  available analytically from a surpyval recurrence model as ``model.cif(t)``
+  (e.g. Crow-AMSAA / NHPP, Duane, HPP).
+- **Imperfect repair** (generalized renewal / Kijima virtual-age) — each repair
+  rejuvenates the unit *partially* (a restoration factor ``0 < q < 1``), so
+  failures still accelerate, but more slowly than under minimal repair.
+  ``E[N(t)]`` has no closed form here and is estimated by (seeded) simulation
+  from a fitted surpyval ``GeneralizedRenewal`` model as ``model.mcf(t)``.
 
-    g(t) = (cr * Lambda(t) + co) / t
+Minimal repair is the ``q = 1`` edge of imperfect repair; perfect repair
+(``q = 0``, a full renewal each time) is the ``NonRepairable`` boundary.
+Whichever the unit is, ``Repairable`` prices the same policy: each repair costs
+``cr`` while an *overhaul / replacement* costs ``co`` (> ``cr``) and renews the
+unit to as-new. Renewing every ``t`` time units makes each cycle a renewal
+cycle costing ``cr * E[N(t)] + co``, so the long-run cost rate is::
 
-Minimising ``g`` gives the optimal overhaul interval (the Barlow-Hunter
-policy). A finite optimum exists only for wear-out models (``Lambda``
-growing super-linearly, e.g. Crow-AMSAA with ``beta > 1``); otherwise
-repairs never become frequent enough for overhauls to pay and the optimal
-interval is infinite.
+    g(t) = (cr * E[N(t)] + co) / t
 
-Contrast with ``NonRepairable``, which models renewal *by replacement*
-("as good as new") and the age-replacement policy. RBD components are
-assumed to renew on repair, so a minimal-repair unit is not a valid RBD
-node model — ``Repairable`` is a standalone component-level tool.
+Minimising ``g`` gives the optimal overhaul/replacement interval (the
+Barlow-Hunter policy). A finite optimum exists only when the unit wears out
+(``E[N(t)]`` growing super-linearly); otherwise repairs never become frequent
+enough for renewal to pay and the optimal interval is infinite.
+
+Contrast with ``NonRepairable``, which models renewal *by replacement* ("as
+good as new") and the age-replacement policy. RBD components are assumed to
+renew on repair, so a repairable unit modelled here is not a valid RBD node
+model — ``Repairable`` is a standalone component-level tool.
 """
 
-from typing import Union
+from typing import Optional, Union
 
 import numpy as np
 from scipy.optimize import minimize_scalar
 
 from repyability.maintenance import MaintenancePolicy
+from repyability.utils.wrappers import numpy_seed
+
+# Simulation draws used to estimate E[N(t)] for a simulation-backed
+# (imperfect-repair) model. Ignored for analytic (``cif``) models.
+_DEFAULT_N_SIMULATIONS = 1000
+
+# Default search horizon for the simulated optimum, as a multiple of the
+# baseline mean-time-to-first-failure. Imperfect repair pushes the optimal
+# renewal interval to several times that mean; simulating much farther is both
+# slow and numerically unstable (the virtual-age process asymptotes), so the
+# horizon is bounded and exposed as ``max_interval``.
+_DEFAULT_HORIZON_MULTIPLE = 15.0
 
 
 class Repairable:
-    """Minimal-repair component with an optimal-overhaul-interval policy.
+    """Repairable component with an optimal overhaul/replacement policy.
 
     Parameters
     ----------
     model : object
-        A recurrent-event model exposing ``cif(t)``, the cumulative
-        intensity (expected number of failures by age ``t``) — e.g. a
-        surpyval recurrence model (``CrowAMSAA``, ``Duane``, ``HPP``),
-        fitted or built ``from_params``.
+        A recurrent-event model exposing the expected number of failures by
+        age ``t``, ``E[N(t)]``, as either:
+
+        - ``cif(t)`` — an analytic cumulative intensity (minimal repair), e.g.
+          a surpyval ``CrowAMSAA``/``Duane``/``HPP`` (fitted or from params);
+          or
+        - ``mcf(t, items=..., seed=...)`` — a simulation-estimated mean
+          cumulative function (imperfect repair), e.g. a fitted surpyval
+          ``GeneralizedRenewal`` (Kijima I/II).
+
+        If both are present ``cif`` is used (analytic, exact).
     """
 
     def __init__(self, model):
-        if not hasattr(model, "cif"):
+        self._analytic = hasattr(model, "cif")
+        if not (self._analytic or hasattr(model, "mcf")):
             raise ValueError(
-                "model must expose cif() (a cumulative intensity "
-                "function), e.g. a surpyval recurrence model such as "
-                "CrowAMSAA"
+                "model must expose cif() (analytic cumulative intensity, e.g. "
+                "a surpyval recurrence model such as CrowAMSAA) or mcf() (a "
+                "simulation-estimated mean cumulative function, e.g. a fitted "
+                "GeneralizedRenewal)"
             )
         self.model = model
 
-    def set_repair_and_overhaul_costs(self, cr: float, co: float) -> None:
-        """Set the minimal-repair cost ``cr`` and overhaul cost ``co``.
+    @property
+    def is_simulated(self) -> bool:
+        """True if ``E[N(t)]`` is estimated by simulation (imperfect repair),
+        so the policy methods honour ``seed``/``n_simulations``."""
+        return not self._analytic
 
-        Requires ``0 < cr < co``: an overhaul (a full renewal) must cost
-        more than a minimal repair, otherwise one would simply overhaul at
-        every failure.
+    def set_repair_and_overhaul_costs(self, cr: float, co: float) -> None:
+        """Set the repair cost ``cr`` and overhaul/replacement cost ``co``.
+
+        Requires ``0 < cr < co``: an overhaul/replacement (a full renewal) must
+        cost more than a repair, otherwise one would simply renew at every
+        failure.
         """
         if cr <= 0:
             raise ValueError("repair cost, cr, must be positive.")
@@ -79,112 +115,231 @@ class Repairable:
                 "first"
             )
 
-    def _cif_scalar(self, t: float) -> float:
-        return float(np.asarray(self.model.cif(t), dtype=float).item())
+    def _expected_failures(
+        self, t, seed: Optional[int], n_simulations: int
+    ) -> np.ndarray:
+        """E[N(t)], the expected number of failures by age ``t``.
 
-    def _g(self, t: float) -> float:
-        """Cost rate at a scalar ``t > 0`` (float in, float out)."""
-        return (self.cr * self._cif_scalar(t) + self.co) / t
+        Analytic via ``cif`` for intensity models; a seeded simulation
+        estimate via ``mcf`` for imperfect-repair (renewal) models.
+        """
+        if self._analytic:
+            return np.asarray(self.model.cif(t), dtype=float)
+        return np.asarray(
+            self.model.mcf(t, items=n_simulations, seed=seed), dtype=float
+        )
 
-    def cost(self, t) -> Union[float, np.ndarray]:
-        """Expected cost of one overhaul cycle of length ``t``:
-        ``cr * Lambda(t) + co``.
+    def _expected_failures_scalar(
+        self, t: float, seed: Optional[int], n_simulations: int
+    ) -> float:
+        return float(
+            np.asarray(
+                self._expected_failures(t, seed, n_simulations), dtype=float
+            ).reshape(-1)[0]
+        )
+
+    def cost(
+        self,
+        t,
+        seed: Optional[int] = None,
+        n_simulations: int = _DEFAULT_N_SIMULATIONS,
+    ) -> Union[float, np.ndarray]:
+        """Expected cost of one overhaul/replacement cycle of length ``t``:
+        ``cr * E[N(t)] + co``.
 
         Scalar ``t`` returns a float; array ``t`` returns an array.
+        ``seed``/``n_simulations`` apply only to a simulation-backed
+        (imperfect-repair) model.
         """
         self._require_costs()
         scalar_in = np.ndim(t) == 0
         tt = np.atleast_1d(np.asarray(t, dtype=float))
-        lam = np.asarray(self.model.cif(tt), dtype=float)
+        lam = self._expected_failures(tt, seed, n_simulations)
         out = self.cr * lam + self.co
         return out.item() if scalar_in else out
 
-    def cost_rate(self, t) -> Union[float, np.ndarray]:
-        """Long-run cost per unit time when overhauling every ``t``:
-        ``(cr * Lambda(t) + co) / t``.
+    def cost_rate(
+        self,
+        t,
+        seed: Optional[int] = None,
+        n_simulations: int = _DEFAULT_N_SIMULATIONS,
+    ) -> Union[float, np.ndarray]:
+        """Long-run cost per unit time when renewing every ``t``:
+        ``(cr * E[N(t)] + co) / t``.
 
         Scalar ``t`` returns a float; array ``t`` returns an array.
+        ``seed``/``n_simulations`` apply only to a simulation-backed
+        (imperfect-repair) model.
         """
         self._require_costs()
         scalar_in = np.ndim(t) == 0
         tt = np.atleast_1d(np.asarray(t, dtype=float))
-        lam = np.asarray(self.model.cif(tt), dtype=float)
+        lam = self._expected_failures(tt, seed, n_simulations)
         with np.errstate(divide="ignore"):
             out = (self.cr * lam + self.co) / tt
         return out.item() if scalar_in else out
 
-    def _optimise(self) -> tuple[float, float]:
-        """Return ``(optimal interval, cost rate at it)``; the interval is
-        ``inf`` (with the limiting repair-only cost rate) when overhauls
-        never pay."""
-        self._require_costs()
+    def _g(self, t: float, seed: Optional[int], n_simulations: int) -> float:
+        """Cost rate at a scalar ``t > 0`` (float in, float out)."""
+        return (
+            self.cr * self._expected_failures_scalar(t, seed, n_simulations)
+            + self.co
+        ) / t
 
-        # At a finite optimum the cumulative repair spend is comparable to
-        # the overhaul cost (for a power law, Lambda(t*) = co/(cr*(b-1))),
-        # so first bracket the age where Lambda(t) reaches co/cr and centre
-        # the search grid on that scale.
+    def _optimise_analytic(self) -> tuple[float, float]:
+        """Analytic optimum for an intensity (``cif``) model; the interval is
+        ``inf`` (with the limiting repair-only cost rate) when overhauls never
+        pay."""
+
+        def enf(t: float) -> float:
+            return self._expected_failures_scalar(t, None, 0)
+
+        def g(t: float) -> float:
+            return self._g(t, None, 0)
+
+        # At a finite optimum the cumulative repair spend is comparable to the
+        # overhaul cost (for a power law, Lambda(t*) = co/(cr*(b-1))), so first
+        # bracket the age where Lambda(t) reaches co/cr and centre the search
+        # grid on that scale.
         target = self.co / self.cr
         t_scale = 1.0
-        if self._cif_scalar(t_scale) < target:
+        if enf(t_scale) < target:
             for _ in range(300):
                 t_scale *= 2.0
-                if self._cif_scalar(t_scale) >= target:
+                if enf(t_scale) >= target:
                     break
         else:
             for _ in range(300):
-                if self._cif_scalar(t_scale / 2.0) < target:
+                if enf(t_scale / 2.0) < target:
                     break
                 t_scale /= 2.0
 
         for _ in range(6):
             grid = t_scale * np.logspace(-4.0, 4.0, 1601)
-            g = np.asarray(self.cost_rate(grid))
-            i = int(np.argmin(g))
+            gr = np.asarray(self.cost_rate(grid))
+            i = int(np.argmin(gr))
             if i == len(grid) - 1:
-                # Minimum at the right edge: overhauling later keeps
-                # getting cheaper. If Lambda is not growing super-linearly
-                # out here, it never stops getting cheaper (no wear-out) —
-                # never overhaul.
+                # Minimum at the right edge: overhauling later keeps getting
+                # cheaper. If Lambda is not growing super-linearly out here, it
+                # never stops getting cheaper (no wear-out) — never overhaul.
                 big_t = float(grid[-1])
-                lam_t = self._cif_scalar(big_t)
-                lam_2t = self._cif_scalar(2.0 * big_t)
+                lam_t = enf(big_t)
+                lam_2t = enf(2.0 * big_t)
                 if lam_t <= 0.0 or (
                     np.log(lam_2t / lam_t) / np.log(2.0) <= 1.0 + 1e-9
                 ):
-                    return float(np.inf), self._g(big_t)
+                    return float(np.inf), g(big_t)
                 t_scale *= 1e4  # genuine wear-out; optimum is further out
                 continue
             if i == 0:
                 t_scale *= 1e-4
                 continue
             res = minimize_scalar(
-                self._g,
+                g,
                 bounds=(float(grid[i - 1]), float(grid[i + 1])),
                 method="bounded",
             )
             t_star = float(res.x)
-            return t_star, self._g(t_star)
+            return t_star, g(t_star)
         # Search saturated (pathological model): best point found.
         t_star = float(grid[i])
-        return t_star, self._g(t_star)
+        return t_star, g(t_star)
 
-    def find_optimal_overhaul_interval(self) -> float:
-        """The overhaul interval minimising the long-run cost rate.
+    def _timescale(self) -> float:
+        """A characteristic time for the failure process, used to centre the
+        search grid without repeated simulation.
 
-        Returns ``inf`` when overhauls never pay: the model does not wear
-        out (``Lambda(t)`` grows at most linearly — e.g. HPP, or Crow-AMSAA
-        with ``beta <= 1``), so the cost rate keeps falling as the
-        interval grows.
+        The baseline mean-time-to-first-failure sets the scale (the optimal
+        renewal interval is a small multiple of it). Falls back to 1.0 if the
+        model does not expose a baseline mean.
         """
-        return self._optimise()[0]
+        baseline = getattr(self.model, "model", None)
+        if baseline is not None and hasattr(baseline, "mean"):
+            try:
+                m = float(np.atleast_1d(baseline.mean())[0])
+                if np.isfinite(m) and m > 0.0:
+                    return m
+            except Exception:
+                pass
+        return 1.0
 
-    def optimal_overhaul_policy(self) -> MaintenancePolicy:
-        """The optimal overhaul policy as a typed result.
+    def _optimise_simulated(
+        self,
+        seed: Optional[int],
+        n_simulations: int,
+        max_interval: Optional[float],
+    ) -> tuple[float, float]:
+        """Grid optimum for a simulation-backed (imperfect-repair) model.
 
-        Returns a ``MaintenancePolicy`` carrying the optimal interval and
-        the long-run cost rate under it. When the interval is ``inf``
-        (never overhaul), the cost rate is the limiting rate of minimal
-        repairs alone.
+        The cost of a seeded ``mcf`` call scales with the sample size and the
+        horizon, not the number of grid points, and a single seeded ``mcf``
+        call over a grid is self-consistent (monotone), so this uses **one**
+        ``mcf`` evaluation over a log grid up to ``max_interval`` and takes the
+        minimum of the (unimodal) cost rate ``(cr*E[N(t)] + co)/t``.
+
+        ``max_interval`` bounds the search: imperfect repair pushes the
+        optimum to several times the baseline mean, and simulating much farther
+        is slow and numerically unstable, so effective-repair cases whose
+        optimum lies beyond the horizon return the horizon (raise
+        ``max_interval`` to search further).
         """
-        interval, rate = self._optimise()
+        with numpy_seed(seed):
+            if max_interval is None:
+                max_interval = _DEFAULT_HORIZON_MULTIPLE * self._timescale()
+
+            grid = max_interval * np.logspace(-2.5, 0.0, 250)
+            gr = np.asarray(
+                self.cost_rate(grid, seed=seed, n_simulations=n_simulations)
+            )
+            i = int(np.nanargmin(gr))
+            return float(grid[i]), float(gr[i])
+
+    def _optimise(
+        self,
+        seed: Optional[int],
+        n_simulations: int,
+        max_interval: Optional[float],
+    ) -> tuple[float, float]:
+        self._require_costs()
+        if self._analytic:
+            return self._optimise_analytic()
+        return self._optimise_simulated(seed, n_simulations, max_interval)
+
+    def find_optimal_overhaul_interval(
+        self,
+        seed: Optional[int] = None,
+        n_simulations: int = _DEFAULT_N_SIMULATIONS,
+        max_interval: Optional[float] = None,
+    ) -> float:
+        """The overhaul/replacement interval minimising the long-run cost rate.
+
+        For an analytic (minimal-repair) model, returns ``inf`` when renewal
+        never pays: the unit does not wear out (``E[N(t)]`` grows at most
+        linearly — e.g. HPP, or Crow-AMSAA with ``beta <= 1``), so the cost
+        rate keeps falling as the interval grows.
+
+        For a simulation-backed (imperfect-repair) model, pass a ``seed`` for a
+        reproducible result; ``n_simulations`` sets the Monte-Carlo sample size
+        and ``max_interval`` the search horizon (default ~15x the baseline
+        mean-time-to-first-failure).
+        """
+        return self._optimise(seed, n_simulations, max_interval)[0]
+
+    def optimal_overhaul_policy(
+        self,
+        seed: Optional[int] = None,
+        n_simulations: int = _DEFAULT_N_SIMULATIONS,
+        max_interval: Optional[float] = None,
+    ) -> MaintenancePolicy:
+        """The optimal overhaul/replacement policy as a typed result.
+
+        Returns a ``MaintenancePolicy`` carrying the optimal interval and the
+        long-run cost rate under it. For an analytic model an ``inf`` interval
+        (never renew) reports the limiting rate of repairs alone.
+
+        For a simulation-backed (imperfect-repair) model, pass a ``seed`` for a
+        reproducible result; ``n_simulations`` sets the Monte-Carlo sample size
+        and ``max_interval`` the search horizon.
+        """
+        interval, rate = self._optimise(seed, n_simulations, max_interval)
         return MaintenancePolicy(interval=interval, cost_rate=rate)

--- a/repyability/tests/test_imperfect_repair.py
+++ b/repyability/tests/test_imperfect_repair.py
@@ -1,0 +1,93 @@
+"""
+Tests the imperfect-repair (generalized-renewal / Kijima) support in the
+``Repairable`` component: sourcing E[N(t)] from a simulation-backed
+``GeneralizedRenewal`` model rather than an analytic ``cif``.
+
+The exact anchors use the ``q = 1`` (minimal-repair) limit, where the
+generalized-renewal process reduces to the baseline's cumulative hazard and the
+optimal overhaul interval has a closed form.
+"""
+
+import numpy as np
+import pytest
+import surpyval as surv
+from surpyval.recurrent import CrowAMSAA, GeneralizedRenewal
+
+from repyability.repairable import Repairable
+
+
+def _gr(q, alpha=100.0, beta=2.0, kijima="ii"):
+    """A generalized-renewal model, Weibull baseline, restoration factor q."""
+    return GeneralizedRenewal.fit_from_parameters(
+        [alpha, beta], q, kijima=kijima, dist=surv.Weibull
+    )
+
+
+def test_is_simulated_flag():
+    # A generalized-renewal (mcf-only) model is simulation-backed...
+    assert Repairable(_gr(0.5)).is_simulated is True
+    # ...while an analytic cumulative-intensity model (cif) is not.
+    analytic = Repairable(CrowAMSAA.from_params([0.5, 1.6]))
+    assert analytic.is_simulated is False
+
+
+def test_requires_cif_or_mcf():
+    class NoCounting:
+        pass
+
+    with pytest.raises(ValueError, match="cif|mcf"):
+        Repairable(NoCounting())
+
+
+def test_q1_expected_failures_matches_cumulative_hazard():
+    """At q=1 the process is minimal repair, so E[N(t)] equals the baseline
+    Weibull cumulative hazard ``(t/alpha)**beta``."""
+    rep = Repairable(_gr(1.0, alpha=100.0, beta=2.0))
+    t = np.array([50.0, 100.0, 150.0])
+    enf = rep._expected_failures(t, seed=3, n_simulations=8000)
+    expected = (t / 100.0) ** 2.0
+    np.testing.assert_allclose(enf, expected, rtol=0.05)
+
+
+def test_cost_and_cost_rate_contract():
+    rep = Repairable(_gr(0.5))
+    rep.set_repair_and_overhaul_costs(1.0, 5.0)
+    assert isinstance(rep.cost(100.0, seed=1, n_simulations=300), float)
+    assert isinstance(rep.cost_rate(100.0, seed=1, n_simulations=300), float)
+    arr = rep.cost_rate(np.array([100.0, 200.0]), seed=1, n_simulations=300)
+    assert isinstance(arr, np.ndarray) and arr.shape == (2,)
+
+
+def test_optimal_interval_matches_analytic_at_q1():
+    """For minimal repair (q=1) with a Weibull baseline the optimal overhaul
+    interval has the closed form ``alpha * (co/(cr*(beta-1))) ** (1/beta)``;
+    the simulated optimum must land near it."""
+    alpha, beta, cr, co = 100.0, 2.0, 1.0, 5.0
+    analytic = alpha * (co / (cr * (beta - 1.0))) ** (1.0 / beta)
+    rep = Repairable(_gr(1.0, alpha=alpha, beta=beta))
+    rep.set_repair_and_overhaul_costs(cr, co)
+    interval = rep.find_optimal_overhaul_interval(
+        seed=2, n_simulations=1200, max_interval=600.0
+    )
+    assert interval == pytest.approx(analytic, rel=0.12)
+
+
+def test_reproducible_with_seed():
+    rep = Repairable(_gr(0.5))
+    rep.set_repair_and_overhaul_costs(1.0, 5.0)
+    p1 = rep.optimal_overhaul_policy(
+        seed=7, n_simulations=400, max_interval=600.0
+    )
+    p2 = rep.optimal_overhaul_policy(
+        seed=7, n_simulations=400, max_interval=600.0
+    )
+    assert p1.interval == p2.interval
+    assert p1.cost_rate == p2.cost_rate
+
+
+def test_costs_required_and_ordered():
+    rep = Repairable(_gr(0.5))
+    with pytest.raises(ValueError, match="costs not set"):
+        rep.find_optimal_overhaul_interval(seed=1, n_simulations=200)
+    with pytest.raises(ValueError, match="less than"):
+        rep.set_repair_and_overhaul_costs(5.0, 1.0)


### PR DESCRIPTION
## Summary

Extends the existing `Repairable` component from minimal repair only to the
whole repair-effectiveness spectrum — **no new class**, per the review that it
belongs in `Repairable`.

`Repairable` now sources the expected number of failures `E[N(t)]` from whatever
recurrent model it is given:

- **Minimal repair (unchanged):** models exposing `cif(t)` (e.g. a surpyval
  `CrowAMSAA`/`Duane`/`HPP`) keep the exact, deterministic overhaul-interval
  optimisation. The analytic path is byte-for-byte the old behaviour.
- **Imperfect repair (new):** a fitted `GeneralizedRenewal` (Kijima I/II)
  exposes only a simulation-estimated `mcf(t)`, so `E[N(t)]` is drawn from a
  **seeded** `mcf`. Minimal repair is the `q = 1` edge of this model; perfect
  repair (`q = 0`) is the `NonRepairable` boundary.

The overhaul/replacement policy keeps its form `(cr·E[N(t)] + co)/t`. For a
simulation-backed model, `optimal_overhaul_policy` / `find_optimal_overhaul_interval`
take `seed` (reproducible), `n_simulations` (sample size) and `max_interval`
(search horizon — imperfect repair pushes the optimum to several times the
baseline mean, and simulating far out is slow and numerically unstable). A
single seeded `mcf` call over a log grid keeps it to one simulation.
`is_simulated` reports which path a `Repairable` uses.

## Type of change

- [x] New feature

## Checklist

- [x] Tests added/updated (asserting against a reference value where possible)
- [x] `black`, `isort`, `flake8`, and `mypy` pass (mypy 2.3.0)
- [x] `coverage run -m pytest` passes and stays above the coverage gate (360 passed, 91%)
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Any Monte-Carlo tests are seeded (deterministic) — the imperfect-repair tests all pass a `seed`

## Notes for reviewers

- The exact anchor is the `q = 1` limit: the simulated optimal interval matches
  the closed form `alpha·(co/(cr·(beta−1)))^(1/beta)` (227 vs 223.6 at
  `n_simulations=1200`), and `E[N(t)]` matches the baseline cumulative hazard.
- Key finding driving the design: `GeneralizedRenewal.mcf` is a *stochastic*
  estimate (no closed form for E[N(t)] under imperfect repair), which is why the
  simulated path is seeded and bounded.
- **Deferred to a follow-up** (as the issue flags as splittable): the
  replace-at-N-th-failure policy + closed-form `E[T_N]`, and the two-level
  repair→overhaul→replace K-cycle policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUGaeQXKxjjiQ1ULT1ApXS

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUGaeQXKxjjiQ1ULT1ApXS)_