### PR TITLE
Replace-at-N-th-failure policy on Repairable (#49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   / `find_optimal_overhaul_interval` take `seed`, `n_simulations` and
   `max_interval` for a reproducible, bounded search, and `is_simulated` reports
   which path a `Repairable` uses.
+- **Replace-at-N-th-failure policy on `Repairable`.** As an alternative to
+  renewing at a fixed age, `optimal_failure_limit_policy` /
+  `find_optimal_replacement_failure_count` price repairing on each failure and
+  replacing at the N-th, minimising `(cr·(n-1) + co) / E[T_n]`, and return a new
+  typed `FailureLimitPolicy(failure_count, cost_rate)`. `E[T_n]` comes from a
+  seeded simulation (`expected_time_to_nth_failure`); for the minimal-repair
+  (power-law) limit the exact closed form is exposed as
+  `minimal_repair_time_to_nth_failure(alpha, beta, n)`.
 
 ### Changed
 - **Harmonised the RBD constructor signatures.** The base ``RBD`` now takes

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -373,6 +373,22 @@ every repair a renewal) the `NonRepairable` boundary. `n_simulations` sets the
 Monte-Carlo sample size and `max_interval` the search horizon — raise it if the
 optimum (which grows as repairs get more effective) sits beyond the default.
 
+Instead of renewing at a fixed *age*, you can renew at a fixed **failure
+count** — repair on each failure and replace at the N-th:
+
+```python
+unit.optimal_failure_limit_policy(seed=0)   # -> FailureLimitPolicy(failure_count, cost_rate)
+unit.expected_time_to_nth_failure(5, seed=0)  # E[T_5] by simulation
+```
+
+For the minimal-repair (`q = 1`, power-law) limit, `E[T_n]` is exact and needs
+no simulation:
+
+```python
+from repyability import minimal_repair_time_to_nth_failure
+minimal_repair_time_to_nth_failure(alpha=1500, beta=2.0, n=5)
+```
+
 ## Saving and loading
 
 An RBD round-trips to a plain, JSON-friendly structure, so it can be saved,

--- a/repyability/__init__.py
+++ b/repyability/__init__.py
@@ -7,7 +7,7 @@ directly from the top-level package, e.g.::
 """
 
 from repyability._version import __version__
-from repyability.maintenance import MaintenancePolicy
+from repyability.maintenance import FailureLimitPolicy, MaintenancePolicy
 from repyability.non_repairable import NonRepairable
 from repyability.rbd.helper_classes import (
     PerfectReliability,
@@ -28,7 +28,10 @@ from repyability.rbd.results import (
     UpDownImportance,
 )
 from repyability.rbd.standby_node import StandbyModel
-from repyability.repairable import Repairable
+from repyability.repairable import (
+    Repairable,
+    minimal_repair_time_to_nth_failure,
+)
 
 __all__ = [
     "__version__",
@@ -46,6 +49,7 @@ __all__ = [
     "PerfectReliability",
     "PerfectUnreliability",
     "NodeState",
+    "minimal_repair_time_to_nth_failure",
     # Result types
     "AvailabilityResult",
     "ConfidenceInterval",
@@ -54,4 +58,5 @@ __all__ = [
     "FailureCriticalityIndex",
     "RestorationCriticalityIndex",
     "MaintenancePolicy",
+    "FailureLimitPolicy",
 ]

--- a/repyability/maintenance.py
+++ b/repyability/maintenance.py
@@ -26,3 +26,24 @@ class MaintenancePolicy:
 
     interval: float
     cost_rate: float
+
+
+@dataclass(frozen=True)
+class FailureLimitPolicy:
+    """An optimal failure-limit (replace-at-N-th-failure) policy.
+
+    Returned by ``Repairable.optimal_failure_limit_policy()``: rather than
+    renewing at a fixed *age*, the unit is repaired on each failure and
+    replaced at the ``failure_count``-th failure.
+
+    Attributes
+    ----------
+    failure_count : int
+        The optimal number of failures per replacement cycle (repairs on the
+        first ``failure_count - 1`` failures, then replace on the last).
+    cost_rate : float
+        The long-run cost per unit time under the policy.
+    """
+
+    failure_count: int
+    cost_rate: float

--- a/repyability/repairable.py
+++ b/repyability/repairable.py
@@ -36,17 +36,38 @@ renew on repair, so a repairable unit modelled here is not a valid RBD node
 model — ``Repairable`` is a standalone component-level tool.
 """
 
+import warnings
 from typing import Optional, Union
 
 import numpy as np
 from scipy.optimize import minimize_scalar
+from scipy.special import gammaln
 
-from repyability.maintenance import MaintenancePolicy
+from repyability.maintenance import FailureLimitPolicy, MaintenancePolicy
 from repyability.utils.wrappers import numpy_seed
 
 # Simulation draws used to estimate E[N(t)] for a simulation-backed
 # (imperfect-repair) model. Ignored for analytic (``cif``) models.
 _DEFAULT_N_SIMULATIONS = 1000
+
+# Default largest failure count searched by the replace-at-N-th-failure policy.
+_DEFAULT_MAX_FAILURES = 30
+
+
+def minimal_repair_time_to_nth_failure(
+    alpha: float, beta: float, n: int
+) -> float:
+    """Expected time to the ``n``-th failure of a minimal-repair (power-law /
+    Weibull-baseline) process: ``alpha * Gamma(n + 1/beta) / Gamma(n)``.
+
+    A closed form for the ``q = 1`` (minimal repair) limit, exact and cheap;
+    used both directly and to anchor the simulated
+    :meth:`Repairable.expected_time_to_nth_failure`.
+    """
+    if n < 1:
+        raise ValueError("n must be a positive integer.")
+    return float(alpha * np.exp(gammaln(n + 1.0 / beta) - gammaln(n)))
+
 
 # Default search horizon for the simulated optimum, as a multiple of the
 # baseline mean-time-to-first-failure. Imperfect repair pushes the optimal
@@ -343,3 +364,141 @@ class Repairable:
         """
         interval, rate = self._optimise(seed, n_simulations, max_interval)
         return MaintenancePolicy(interval=interval, cost_rate=rate)
+
+    # -- Replace-at-N-th-failure policy ------------------------------------
+
+    def _require_simulation(self) -> None:
+        if self._analytic:
+            raise ValueError(
+                "the N-th-failure policy needs an imperfect-repair "
+                "(simulation-backed) model; for a power-law minimal-repair "
+                "process use minimal_repair_time_to_nth_failure() directly."
+            )
+
+    def _expected_times_to_failures(
+        self, max_failures: int, seed: Optional[int], n_simulations: int
+    ) -> np.ndarray:
+        """``[E[T_1], ..., E[T_k]]`` from a single seeded count-terminated
+        simulation, where ``k <= max_failures``.
+
+        Simulating to the ``max_failures``-th failure records every earlier
+        failure time too, so one simulation yields the whole curve, and for
+        each item the ``n``-th failure time is its ``n``-th ordered event. The
+        surpyval simulator can become unstable (NaN interarrival times) at high
+        failure counts for near-minimal repair; if it does, the horizon is
+        halved until it succeeds and the (shorter) achievable curve is
+        returned with a warning.
+        """
+        self._require_simulation()
+        with numpy_seed(seed):
+            achievable = max_failures
+            result = None
+            while achievable >= 1:
+                try:
+                    result = self.model.count_terminated_simulation(
+                        achievable, items=n_simulations, seed=seed
+                    )
+                    break
+                except (ValueError, FloatingPointError):
+                    achievable //= 2
+            if result is None:
+                raise ValueError(
+                    "could not simulate the failure process; the model may be "
+                    "degenerate."
+                )
+        if achievable < max_failures:
+            warnings.warn(
+                "the failure simulator became unstable beyond "
+                f"{achievable} failures; the search was truncated from "
+                f"{max_failures}. For minimal repair use "
+                "minimal_repair_time_to_nth_failure().",
+                stacklevel=3,
+            )
+        data = result.data
+        x = np.asarray(data.x, dtype=float)
+        item = np.asarray(data.i)
+
+        # Order by (item, time), then read the n-th event of each item block.
+        order = np.lexsort((x, item))
+        xs, items = x[order], item[order]
+        ids = np.arange(1, n_simulations + 1)
+        starts = np.searchsorted(items, ids, side="left")
+        ends = np.searchsorted(items, ids, side="right")
+
+        expected = np.empty(achievable, dtype=float)
+        for n in range(1, achievable + 1):
+            idx = starts + (n - 1)
+            valid = idx < ends
+            expected[n - 1] = np.nanmean(xs[idx[valid]])
+        return expected
+
+    def expected_time_to_nth_failure(
+        self,
+        n: int,
+        seed: Optional[int] = None,
+        n_simulations: int = _DEFAULT_N_SIMULATIONS,
+    ) -> float:
+        """Expected time to the ``n``-th failure, ``E[T_n]``.
+
+        Estimated by a seeded simulation for an imperfect-repair model. For a
+        minimal-repair (power-law) process the closed form
+        :func:`minimal_repair_time_to_nth_failure` is exact and cheaper.
+        """
+        if n < 1:
+            raise ValueError("n must be a positive integer.")
+        curve = self._expected_times_to_failures(n, seed, n_simulations)
+        if len(curve) < n:
+            raise ValueError(
+                f"the simulator could not reach {n} failures for this model "
+                "(near-minimal repair); use "
+                "minimal_repair_time_to_nth_failure() instead."
+            )
+        return float(curve[n - 1])
+
+    def _optimise_failure_limit(
+        self, seed: Optional[int], n_simulations: int, max_failures: int
+    ) -> tuple[int, float]:
+        self._require_costs()
+        expected = self._expected_times_to_failures(
+            max_failures, seed, n_simulations
+        )
+        n = np.arange(1, len(expected) + 1)
+        # Replace at the n-th failure: n-1 repairs (cr each) then a replacement
+        # (co), over an expected cycle length E[T_n].
+        cost_rate = (self.cr * (n - 1) + self.co) / expected
+        i = int(np.nanargmin(cost_rate))
+        return int(n[i]), float(cost_rate[i])
+
+    def find_optimal_replacement_failure_count(
+        self,
+        seed: Optional[int] = None,
+        n_simulations: int = _DEFAULT_N_SIMULATIONS,
+        max_failures: int = _DEFAULT_MAX_FAILURES,
+    ) -> int:
+        """The number of failures per cycle minimising the long-run cost rate
+        of a replace-at-N-th-failure policy.
+
+        Simulation-based; pass a ``seed`` for a reproducible result.
+        ``max_failures`` bounds the search (raise it if the optimum sits at the
+        bound).
+        """
+        return self._optimise_failure_limit(seed, n_simulations, max_failures)[
+            0
+        ]
+
+    def optimal_failure_limit_policy(
+        self,
+        seed: Optional[int] = None,
+        n_simulations: int = _DEFAULT_N_SIMULATIONS,
+        max_failures: int = _DEFAULT_MAX_FAILURES,
+    ) -> FailureLimitPolicy:
+        """The optimal replace-at-N-th-failure policy as a typed result.
+
+        Repair on each failure (cost ``cr``) and replace on the
+        ``failure_count``-th (cost ``co``); the long-run cost rate is
+        ``(cr*(n-1) + co) / E[T_n]`` minimised over ``n``.
+        """
+        count, rate = self._optimise_failure_limit(
+            seed, n_simulations, max_failures
+        )
+        return FailureLimitPolicy(failure_count=count, cost_rate=rate)

--- a/repyability/tests/test_imperfect_repair.py
+++ b/repyability/tests/test_imperfect_repair.py
@@ -13,7 +13,11 @@ import pytest
 import surpyval as surv
 from surpyval.recurrent import CrowAMSAA, GeneralizedRenewal
 
-from repyability.repairable import Repairable
+from repyability.maintenance import FailureLimitPolicy
+from repyability.repairable import (
+    Repairable,
+    minimal_repair_time_to_nth_failure,
+)
 
 
 def _gr(q, alpha=100.0, beta=2.0, kijima="ii"):
@@ -91,3 +95,64 @@ def test_costs_required_and_ordered():
         rep.find_optimal_overhaul_interval(seed=1, n_simulations=200)
     with pytest.raises(ValueError, match="less than"):
         rep.set_repair_and_overhaul_costs(5.0, 1.0)
+
+
+# -- Replace-at-N-th-failure policy ---------------------------------------
+
+
+def test_minimal_repair_time_to_nth_failure_closed_form():
+    # T_1 is just the baseline mean: alpha * Gamma(1 + 1/beta).
+    from scipy.special import gamma
+
+    assert minimal_repair_time_to_nth_failure(100.0, 2.0, 1) == pytest.approx(
+        100.0 * gamma(1.5)
+    )
+    # A monotone increasing sequence.
+    ts = [
+        minimal_repair_time_to_nth_failure(100.0, 2.0, n) for n in range(1, 6)
+    ]
+    assert all(a < b for a, b in zip(ts, ts[1:]))
+    with pytest.raises(ValueError):
+        minimal_repair_time_to_nth_failure(100.0, 2.0, 0)
+
+
+def test_expected_time_to_nth_failure_matches_closed_form_at_q1():
+    rep = Repairable(_gr(1.0, alpha=100.0, beta=2.0))
+    for n in (3, 6):
+        sim = rep.expected_time_to_nth_failure(n, seed=1, n_simulations=5000)
+        exact = minimal_repair_time_to_nth_failure(100.0, 2.0, n)
+        assert sim == pytest.approx(exact, rel=0.05)
+
+
+def test_expected_time_to_nth_failure_analytic_raises():
+    analytic = Repairable(CrowAMSAA.from_params([0.5, 1.6]))
+    with pytest.raises(ValueError, match="minimal_repair_time_to_nth_failure"):
+        analytic.expected_time_to_nth_failure(3)
+
+
+def test_expected_time_to_nth_failure_validation():
+    rep = Repairable(_gr(0.5))
+    with pytest.raises(ValueError, match="positive"):
+        rep.expected_time_to_nth_failure(0, seed=1, n_simulations=200)
+
+
+def test_optimal_failure_limit_policy():
+    rep = Repairable(_gr(0.4, kijima="i"))
+    rep.set_repair_and_overhaul_costs(1.0, 5.0)
+    policy = rep.optimal_failure_limit_policy(
+        seed=3, n_simulations=1200, max_failures=25
+    )
+    assert isinstance(policy, FailureLimitPolicy)
+    assert policy.failure_count >= 1
+    assert policy.cost_rate > 0
+    # Reproducible for a fixed seed.
+    again = rep.optimal_failure_limit_policy(
+        seed=3, n_simulations=1200, max_failures=25
+    )
+    assert policy == again
+
+
+def test_failure_limit_costs_required():
+    rep = Repairable(_gr(0.5))
+    with pytest.raises(ValueError, match="costs not set"):
+        rep.find_optimal_replacement_failure_count(seed=1, n_simulations=200)


### PR DESCRIPTION
## Summary

Adds the second maintenance policy from #49 — a **failure-limit** (replace-at-N-th-failure) policy on `Repairable`, alongside the age-based overhaul policy already shipped.

- **`optimal_failure_limit_policy` / `find_optimal_replacement_failure_count`** — repair on each failure (cost `cr`) and replace at the N-th (cost `co`), minimising `(cr·(n-1) + co) / E[T_n]`; returns a new typed **`FailureLimitPolicy(failure_count, cost_rate)`**.
- **`expected_time_to_nth_failure(n, seed)`** — estimates `E[T_n]` from **one** seeded `count_terminated_simulation` (which records every earlier failure, so a single run yields the whole `E[T_1..N]` curve).
- **`minimal_repair_time_to_nth_failure(alpha, beta, n)`** — the exact closed form `α·Γ(n+1/β)/Γ(n)` for the minimal-repair (power-law) limit, both a standalone helper and the test anchor.

## Type of change

- [x] New feature

## Checklist

- [x] Tests added/updated (asserting against a reference value where possible)
- [x] `black`, `isort`, `flake8`, and `mypy` pass (mypy 2.3.0)
- [x] `coverage run -m pytest` passes and stays above the coverage gate (366 passed, 91%)
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Any Monte-Carlo tests are seeded (deterministic)

## Notes for reviewers

- Anchor: the simulated `E[T_n]` matches the closed form (166.13 vs 166.17 at n=3; 239.85 vs 239.90 at n=6).
- **surpyval robustness:** `count_terminated_simulation` produces NaN interarrival times and raises at high failure counts for *near-minimal* repair (empirically stable to ~15 failures at `q=1`, to 40+ at `q=0.4`). The simulation halves its horizon until it succeeds and warns; the minimal-repair case has the exact closed form instead. Analytic (`cif`-only) models raise, pointing to the closed form.
- The two-level *repair→overhaul→replace* K-cycle policy (the third #49 bullet) is **still outstanding** — it needs a bespoke virtual-age simulation with periodic imperfect overhauls, which I'll do as its own piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUGaeQXKxjjiQ1ULT1ApXS

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUGaeQXKxjjiQ1ULT1ApXS)_