### PR TITLE
Add RegressionNode for covariate-dependent components (#37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   seeded simulation (`expected_time_to_nth_failure`); for the minimal-repair
   (power-law) limit the exact closed form is exposed as
   `minimal_repair_time_to_nth_failure(alpha, beta, n)`.
+- **`RegressionNode`: covariate-dependent components in an RBD.** A new node
+  wraps a fitted surpyval **regression** survival model (accelerated-failure-
+  time, proportional-hazards/Cox, proportional-odds, ...) together with a fixed
+  covariate vector `Z` — the component's operating conditions — so its
+  reliability is `model.sf(x, Z)`. It is an ordinary univariate node: system
+  reliability, importance, MTTF and the condition-based (`age`) layer all work
+  with no special handling, because at fixed covariates
+  `R(x | age) = sf(age + x, Z) / sf(age, Z)` holds for every regression family.
+  The fitted model serialises with the RBD via `surpyval.from_dict`. Simulation-
+  based `mean`/`random` require a proper parametric lifetime (AFT/PO/parametric);
+  a semiparametric Cox baseline has no defined MTTF and says so clearly. (#37)
 
 ### Changed
+- **Bumped the surpyval pin to `>=0.15,<0.16`** (from `>=0.13,<0.14`), for the
+  regression-model serialisation (`to_dict`/`surpyval.from_dict`) that
+  `RegressionNode` relies on. No change to existing behaviour.
 - **Harmonised the RBD constructor signatures.** The base ``RBD`` now takes
   ``(edges, nodes, k, ...)`` instead of ``(edges, k, nodes, ...)``, so all
   three classes share the same positional order: the structure first (``edges``

--- a/docs/api.md
+++ b/docs/api.md
@@ -23,6 +23,8 @@ the top-level `repyability` package).
 
 ::: repyability.Repairable
 
+::: repyability.RegressionNode
+
 ## Helpers
 
 ::: repyability.NodeState

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -190,6 +190,50 @@ release supports ordinary distribution components — dynamic nodes (standby) an
 composite nodes raise if given a state. The structure is static (persist it via
 serialisation); state is transient input you supply per evaluation.
 
+### Covariate-dependent components (regression nodes)
+
+A component's reliability often depends on the *conditions it runs under* —
+temperature, current, cycle rate, duty. If you have fitted a **regression**
+survival model in surpyval (accelerated-failure-time, proportional-hazards
+(Cox), proportional-odds, ...), a [`RegressionNode`][repyability.RegressionNode]
+uses it in an RBD by pinning a **covariate vector** `Z` (this component's
+operating conditions). Its reliability is just the model's survival at those
+covariates:
+
+```
+R(x) = model.sf(x, Z)
+```
+
+so it is an ordinary univariate node — it takes part in system reliability,
+importance, MTTF and the condition-based (`age`) layer with no special
+handling. Fit the model in surpyval (RePyability consumes it) and pin the
+covariates:
+
+```python
+import surpyval as surv
+from repyability import NonRepairableRBD, RegressionNode, NodeState
+
+aft = surv.WeibullAFT.fit(failure_times, Z=covariates)   # fitted in surpyval
+motor = RegressionNode(aft, covariates=[0.6])            # runs hot (Z = 0.6)
+
+rbd = NonRepairableRBD([("s", "m"), ("m", "t")], {"m": motor})
+
+rbd.sf(30)                                       # reliability of a new motor
+rbd.sf_given_state(30, {"m": NodeState(age=40)}) # ...given 40 hours already run
+rbd.remaining_life(0.9, {"m": NodeState(age=40)})
+```
+
+- Because the covariates are fixed on the node, `age` keeps its single, ordinary
+  meaning (operating time survived): `R(x | age) = sf(age + x, Z) / sf(age, Z)`,
+  which holds for every regression family. A hotter-running motor is simply a
+  node with different covariates.
+- The node serialises with the RBD — the fitted regression model round-trips
+  through `surpyval.from_dict`.
+- `mean` and `random` (simulation-based MTTF) need a proper parametric lifetime,
+  so they work for AFT/PO/parametric models; a *semiparametric* Cox baseline has
+  no defined MTTF and reports that clearly. Reliability, conditioning and
+  importance work for all of them.
+
 ## Repairable systems and availability
 
 A [`RepairableRBD`][repyability.RepairableRBD] takes components with both a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "numpy>=2.0,<3",
     "scipy>=1.7",
     "networkx>=3.0",
-    "surpyval>=0.13,<0.14",
+    "surpyval>=0.15,<0.16",
     "tqdm>=4.64",
 ]
 

--- a/repyability/__init__.py
+++ b/repyability/__init__.py
@@ -16,6 +16,7 @@ from repyability.rbd.helper_classes import (
 from repyability.rbd.node_state import NodeState
 from repyability.rbd.non_repairable_rbd import NonRepairableRBD
 from repyability.rbd.rbd import RBD
+from repyability.rbd.regression_node import RegressionNode
 from repyability.rbd.repairable_rbd import RepairableRBD
 from repyability.rbd.repeated_node import RepeatedNode
 from repyability.rbd.repeated_standby_node import RepeatedStandbyNode
@@ -49,6 +50,7 @@ __all__ = [
     "PerfectReliability",
     "PerfectUnreliability",
     "NodeState",
+    "RegressionNode",
     "minimal_repair_time_to_nth_failure",
     # Result types
     "AvailabilityResult",

--- a/repyability/rbd/node_state.py
+++ b/repyability/rbd/node_state.py
@@ -24,19 +24,19 @@ class NodeState:
     Parameters
     ----------
     age : float, optional
-        The component's current age / accumulated exposure ``X_i`` (``>= 0``),
-        by default ``0.0`` (a brand-new component, equivalent to no
-        conditioning).
+        The component's current age / accumulated operating time (``>= 0``), by
+        default ``0.0`` (a brand-new component, equivalent to no conditioning).
     alive : bool, optional
         Whether the component is currently working, by default ``True``.
 
     Notes
     -----
     Only lifetime (time-varying) distributions age; a fixed-probability
-    component's reliability does not depend on ``age``. Load/stress is not part
-    of the state in this release -- it is a planned extension (accelerated-life
-    exposure and load sharing), at which point this class gains a further
-    field.
+    component's reliability does not depend on ``age``. Covariate/load
+    dependence is a property of the *component*, not its transient state: a
+    :class:`~repyability.rbd.regression_node.RegressionNode` stores the
+    covariates, so ``age`` keeps a single meaning (operating time) for every
+    node type.
     """
 
     age: float = 0.0

--- a/repyability/rbd/regression_node.py
+++ b/repyability/rbd/regression_node.py
@@ -1,0 +1,169 @@
+"""Regression node: an RBD node whose reliability depends on stored covariates.
+
+A :class:`RegressionNode` wraps a fitted surpyval **regression** model (an
+accelerated-failure-time, proportional-hazards, proportional-odds, ... model)
+together with a fixed **covariate vector** ``Z`` -- the operating conditions of
+this component in the system. Its reliability is simply the model's survival at
+those covariates::
+
+    R(x) = model.sf(x, Z)
+
+so a regression node is an ordinary univariate node: it takes part in system
+reliability, importance, MTTF and the condition-based (``age``) layer exactly
+like any other node, with no special handling. Conditioning on age keeps its
+usual meaning -- operating time survived -- because at a fixed covariate the
+component has a plain univariate lifetime and
+``R(x | age) = sf(age + x, Z) / sf(age, Z)`` holds for every regression family.
+
+RePyability *consumes* the fitted model; do the regression fit in surpyval.
+See issue #37.
+"""
+
+from typing import Any
+
+import numpy as np
+from numpy.typing import ArrayLike
+
+
+class RegressionNode:
+    """An RBD node backed by a fitted surpyval regression model at fixed
+    covariates.
+
+    Parameters
+    ----------
+    model : surpyval regression model
+        A fitted regression model whose ``sf(x, Z)`` gives survival at a
+        covariate matrix ``Z`` (e.g. ``surpyval.WeibullAFT.fit(...)``,
+        ``surpyval.CoxPH.fit(...)``).
+    covariates : array_like
+        The component's covariate vector ``Z`` (the operating conditions),
+        matching the covariates the model was fitted with.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import surpyval as surv
+    >>> from repyability.rbd.regression_node import RegressionNode
+    >>> rng = np.random.default_rng(0)
+    >>> Z = rng.normal(size=(300, 1))
+    >>> x = rng.weibull(2.0, size=300) * 100 + 1e-3
+    >>> model = surv.WeibullAFT.fit(x, Z=Z)
+    >>> node = RegressionNode(model, covariates=[0.5])
+    >>> bool(0.0 < node.sf(np.array([50.0]))[0] < 1.0)
+    True
+    """
+
+    def __init__(self, model: Any, covariates: ArrayLike):
+        self.model = model
+        self.covariates = np.atleast_1d(np.asarray(covariates, dtype=float))
+        # Probe the regression interface so a misuse (a non-regression model,
+        # or covariates of the wrong width) fails clearly at construction.
+        try:
+            probe = self._sf_at(np.array([1.0]))
+            if not np.all(np.isfinite(probe)):
+                raise ValueError("sf(x, Z) returned non-finite values")
+        except Exception as e:
+            raise ValueError(
+                "RegressionNode requires a fitted surpyval regression model "
+                "whose sf(x, Z) accepts a covariate matrix, and covariates "
+                f"matching the model's fitted width. Probing sf failed: "
+                f"{type(e).__name__}: {e}."
+            ) from e
+        # Cached (t, sf(t)) grid for mean()/random() (built lazily).
+        self._grid: Any = None
+
+    def _Z(self, n: int) -> np.ndarray:
+        """The covariate vector broadcast to ``n`` rows for ``sf(x, Z)``."""
+        return np.repeat(self.covariates[np.newaxis, :], n, axis=0)
+
+    def _sf_at(self, x: np.ndarray) -> np.ndarray:
+        x = np.atleast_1d(np.asarray(x, dtype=float))
+        return np.asarray(self.model.sf(x, self._Z(len(x))), dtype=float)
+
+    # -- Node reliability interface ---------------------------------------
+
+    def sf(self, x: ArrayLike) -> np.ndarray:
+        """Reliability at the stored covariates: ``model.sf(x, Z)``."""
+        return self._sf_at(np.atleast_1d(np.asarray(x, dtype=float)))
+
+    def ff(self, x: ArrayLike) -> np.ndarray:
+        """Unreliability at the stored covariates: ``1 - sf(x)``."""
+        return 1.0 - self.sf(x)
+
+    def _survival_grid(self):
+        """A cached ``(t, sf(t))`` grid spanning the bulk of the lifetime.
+
+        surpyval's regression models expose no working ``random``, so ``mean``
+        and ``random`` are obtained from the survival curve directly (a numeric
+        integral, and inverse-transform sampling). This needs a *proper*
+        lifetime curve (starting at ~1 and decaying to 0); a semiparametric
+        baseline (e.g. surpyval's Cox) is defined only on the observed range
+        and has no proper tail, so MTTF/simulation is undefined there and is
+        reported as a clear error rather than a wrong number.
+        """
+        if self._grid is None:
+            if float(self._sf_at(np.array([1e-9]))[0]) <= 0.99:
+                raise ValueError(
+                    "mean()/random() need a proper parametric survival curve "
+                    "(sf(0+) ~ 1, decaying to 0), but this model's survival "
+                    "is improper -- e.g. a semiparametric Cox baseline, "
+                    "defined only on the observed range. Its MTTF is "
+                    "undefined; use the sf-based reliability / remaining-life "
+                    "methods instead."
+                )
+            hi = 1.0
+            while self._sf_at(np.array([hi]))[0] > 1e-4:
+                hi *= 2.0
+                if hi > 1e15:
+                    raise ValueError(
+                        "mean()/random(): the survival curve does not decay "
+                        "to 0 (no finite MTTF). Use the sf-based methods."
+                    )
+            t = np.linspace(0.0, hi, 4096)
+            self._grid = (t, self._sf_at(t))
+        return self._grid
+
+    def mean(self) -> float:
+        """Mean time to failure at the stored covariates.
+
+        For a non-negative lifetime ``E[T] = integral of R(t)``, integrated
+        numerically over the survival curve.
+        """
+        t, s = self._survival_grid()
+        return float(np.trapezoid(s, t))
+
+    def random(self, size: int) -> np.ndarray:
+        """Draw ``size`` failure times at the stored covariates.
+
+        Inverse-transform sampling on the survival curve. Uses numpy's global
+        RNG, so wrap the call in
+        :func:`~repyability.utils.wrappers.numpy_seed` to reproduce.
+        """
+        t, s = self._survival_grid()
+        u = np.random.uniform(size=size)
+        # s decreases in t; np.interp needs an increasing sample-point array.
+        return np.interp(u, s[::-1], t[::-1])
+
+    # -- Serialisation ----------------------------------------------------
+
+    def to_dict(self) -> dict:
+        """Serialise to a JSON-friendly dict (the fitted model + covariates).
+        See :meth:`from_dict`."""
+        return {
+            "model": self.model.to_dict(),
+            "covariates": [float(v) for v in self.covariates],
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "RegressionNode":
+        """Reconstruct from :meth:`to_dict` (the fitted model round-trips
+        through ``surpyval.from_dict``)."""
+        import surpyval
+
+        return cls(surpyval.from_dict(d["model"]), d["covariates"])
+
+    def __repr__(self) -> str:
+        return (
+            f"RegressionNode({type(self.model).__name__}, "
+            f"covariates={list(self.covariates)})"
+        )

--- a/repyability/rbd/serialisation.py
+++ b/repyability/rbd/serialisation.py
@@ -34,6 +34,7 @@ from repyability.rbd.helper_classes import (
     PerfectUnreliability,
 )
 from repyability.rbd.rbd import RBD
+from repyability.rbd.regression_node import RegressionNode
 from repyability.rbd.repeated_node import PARALLEL, RepeatedNode
 from repyability.rbd.repeated_standby_node import RepeatedStandbyNode
 from repyability.rbd.standby_node import StandbyModel
@@ -81,6 +82,8 @@ def serialise_model(model: Any) -> dict:
             "reliability": serialise_model(model.reliability),
             "time_to_replace": serialise_model(model.time_to_replace),
         }
+    if isinstance(model, RegressionNode):
+        return {"kind": "regression_node", **model.to_dict()}
     dist = distribution_name(model)
     if dist is not None:
         return {
@@ -135,6 +138,8 @@ def deserialise_model(d: dict) -> Any:
             deserialise_model(d["reliability"]),
             deserialise_model(d["time_to_replace"]),
         )
+    if kind == "regression_node":
+        return RegressionNode.from_dict(d)
     raise ValueError(f"Unknown model kind {kind!r}.")
 
 

--- a/repyability/tests/test_regression_node.py
+++ b/repyability/tests/test_regression_node.py
@@ -1,0 +1,184 @@
+"""Tests for :class:`RegressionNode` (issue #37): an RBD node backed by a
+fitted surpyval regression model at a fixed set of covariates.
+
+The node is deliberately family-agnostic -- it works for accelerated-failure-
+time, proportional-hazards (Cox) and proportional-odds models alike, because
+its reliability is just ``model.sf(x, Z)`` at the stored covariates ``Z`` and
+everything else (system reliability, age conditioning, MTTF, serialisation)
+follows from that single univariate survival curve.
+"""
+
+import json
+
+import numpy as np
+import pytest
+import surpyval as surv
+
+from repyability import NodeState, NonRepairableRBD, RegressionNode
+
+
+@pytest.fixture(scope="module")
+def data():
+    rng = np.random.default_rng(0)
+    Z = rng.normal(size=(400, 1))
+    x = rng.weibull(1.8, size=400) * 80.0 * np.exp(-0.4 * Z[:, 0]) + 1e-3
+    return x, Z
+
+
+@pytest.fixture(scope="module")
+def models(data):
+    x, Z = data
+    return {
+        "aft": surv.WeibullAFT.fit(x, Z=Z),
+        "ph": surv.CoxPH.fit(x, Z=Z),
+        "po": surv.ProportionalOddsFitter(surv.Weibull).fit(x, Z=Z),
+    }
+
+
+def _Z(cov, n):
+    return np.repeat(np.atleast_2d(cov), n, axis=0)
+
+
+# -- reliability matches the model at the stored covariates ----------------
+
+
+@pytest.mark.parametrize("family", ["aft", "ph", "po"])
+def test_sf_matches_model_at_covariates(models, family):
+    model = models[family]
+    node = RegressionNode(model, covariates=[0.3])
+    xt = np.array([5.0, 20.0, 60.0])
+    assert np.allclose(node.sf(xt), model.sf(xt, _Z([0.3], len(xt))))
+    assert np.allclose(node.ff(xt), 1.0 - node.sf(xt))
+
+
+@pytest.mark.parametrize("family", ["aft", "ph", "po"])
+def test_covariates_change_reliability(models, family):
+    model = models[family]
+    xt = np.array([30.0])
+    # In this data a higher covariate shortens life, so it lowers reliability.
+    hi = RegressionNode(model, covariates=[0.6]).sf(xt)[0]
+    lo = RegressionNode(model, covariates=[-0.6]).sf(xt)[0]
+    assert hi < lo
+
+
+# -- mean / random (simulation paths) -------------------------------------
+
+
+def test_mean_and_random(models):
+    node = RegressionNode(models["aft"], covariates=[0.2])
+    assert node.mean() > 0.0
+    np.random.seed(0)
+    a = node.random(20000)
+    np.random.seed(0)
+    b = node.random(20000)
+    assert np.allclose(a, b)  # reproducible under a fixed global seed
+    assert (a > 0).all()
+    # sample mean tracks the integrated mean
+    assert a.mean() == pytest.approx(node.mean(), rel=0.05)
+
+
+def test_semiparametric_mean_random_raise_clearly(models):
+    # A semiparametric Cox baseline has no proper tail, so MTTF is undefined;
+    # mean/random must raise rather than return a wrong number; sf works.
+    node = RegressionNode(models["ph"], covariates=[0.2])
+    assert 0.0 < node.sf(np.array([20.0]))[0] < 1.0
+    with pytest.raises(ValueError, match="proper|Cox|undefined"):
+        node.mean()
+    with pytest.raises(ValueError, match="proper|Cox|undefined"):
+        node.random(10)
+
+
+# -- age conditioning is the ordinary, uniform mechanism ------------------
+
+
+@pytest.mark.parametrize("family", ["aft", "ph", "po"])
+def test_age_conditioning_is_plain_conditional_survival(models, family):
+    # A single regression component in series: system reliability given the
+    # component's age is exactly sf(age + x) / sf(age) -- no special handling.
+    node = RegressionNode(models[family], covariates=[0.4])
+    rbd = NonRepairableRBD([("s", "a"), ("a", "t")], {"a": node})
+    a, x = 25.0, 15.0
+    got = float(rbd.sf_given_state(x, {"a": NodeState(age=a)}))
+    expected = node.sf(np.array([a + x]))[0] / node.sf(np.array([a]))[0]
+    assert got == pytest.approx(expected)
+
+
+# -- inside a larger RBD --------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def rbd(models):
+    return NonRepairableRBD(
+        [("s", "a"), ("a", "b"), ("b", "t")],
+        {
+            # A parametric regression model has a proper lifetime, so the
+            # simulation paths (node_mttf / mean) are well-defined.
+            "a": RegressionNode(models["aft"], covariates=[0.5]),
+            "b": surv.Weibull.from_params([120.0, 2.5]),
+        },
+    )
+
+
+def test_rbd_is_time_varying_and_evaluates(rbd):
+    assert rbd.is_time_varying
+    assert 0.0 < float(rbd.sf(30.0)) < 1.0
+
+
+def test_rbd_condition_and_rul(rbd):
+    st = {"a": NodeState(age=40.0)}
+    worn = float(rbd.sf_given_state(30.0, st))
+    fresh = float(rbd.sf_given_state(30.0, {}))
+    assert worn < fresh  # a worn component lowers go-forward reliability
+    assert rbd.remaining_life(0.8, st) > 0.0
+
+
+def test_dead_regression_node_contributes_zero(rbd):
+    r = float(rbd.sf_given_state(10.0, {"a": NodeState(alive=False)}))
+    assert r == pytest.approx(0.0)
+
+
+def test_importances_and_mttf_with_regression_node(rbd):
+    imp = rbd.importances_given_state(30.0, {"a": NodeState(age=40.0)})
+    assert set(imp) == {"birnbaum", "criticality"}
+    assert "a" in imp["birnbaum"] and "b" in imp["birnbaum"]
+    mttf = rbd.node_mttf(mc_samples=1500, seed=1)
+    assert mttf["a"] > 0.0 and mttf["b"] > 0.0
+    assert rbd.mean(2000, seed=1) > 0.0
+
+
+# -- serialisation --------------------------------------------------------
+
+
+@pytest.mark.parametrize("family", ["aft", "ph", "po"])
+def test_node_dict_roundtrip(models, family):
+    node = RegressionNode(models[family], covariates=[0.3])
+    node2 = RegressionNode.from_dict(json.loads(json.dumps(node.to_dict())))
+    xt = np.array([5.0, 25.0, 70.0])
+    assert np.allclose(node.sf(xt), node2.sf(xt))
+    assert np.allclose(node2.covariates, node.covariates)
+
+
+def test_rbd_with_regression_node_json_roundtrip(rbd):
+    restored = NonRepairableRBD.from_json(rbd.to_json())
+    st = {"a": NodeState(age=40.0)}
+    assert np.isclose(
+        float(rbd.sf_given_state(30.0, st)),
+        float(restored.sf_given_state(30.0, st)),
+    )
+
+
+# -- construction validation ----------------------------------------------
+
+
+def test_wrong_covariate_width_rejected(models):
+    # The model was fitted with one covariate; two is a mismatch.
+    with pytest.raises(ValueError, match="regression model|covariates"):
+        RegressionNode(models["aft"], covariates=[0.1, 0.2])
+
+
+def test_non_regression_model_rejected():
+    # A plain univariate distribution has no sf(x, Z) covariate interface.
+    with pytest.raises(ValueError, match="regression model|covariates"):
+        RegressionNode(
+            surv.Weibull.from_params([100.0, 2.0]), covariates=[0.1]
+        )


### PR DESCRIPTION
## Summary

Adds `RegressionNode` (#37): an RBD node backed by a fitted surpyval **regression** survival model plus a fixed **covariate vector** `Z` — the component's operating conditions. Its reliability is simply `model.sf(x, Z)`, so it is an ordinary univariate node.

Because the covariates are a property of the *component* (not transient state), `age` keeps a single meaning — operating time — for every node type, and the condition-based layer needs **no** special-casing: at fixed covariates `R(x | age) = sf(age+x, Z) / sf(age, Z)` holds for every regression family (accelerated-failure-time, proportional-hazards/Cox, proportional-odds). System reliability, importance, MTTF and serialisation all follow from that single survival curve.

- New `repyability/rbd/regression_node.py`: `sf`/`ff` at the stored covariates; `mean`/`random` for simulation (a proper parametric lifetime is required — a semiparametric Cox baseline has no defined MTTF and raises a clear error rather than returning a wrong number); `to_dict`/`from_dict` (the fitted model round-trips via `surpyval.from_dict`).
- RBD (de)serialisation handles regression nodes; `RegressionNode` exported from the top-level package.
- surpyval pin bumped `>=0.13,<0.14` → `>=0.15,<0.16` for the regression-model serialisation. The full existing suite passes unchanged on 0.15.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Refactor / tooling
- [ ] Breaking change

## Checklist

- [x] Tests added/updated (asserting against a reference value where possible)
- [x] `black`, `isort`, `flake8`, and `mypy` pass
- [x] `coverage run -m pytest` passes and stays above the coverage gate
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Any Monte-Carlo tests are seeded (deterministic)

## Notes for reviewers

- **Design:** deliberately minimal — a regression node just stores covariates. There is no per-node exposure/virtual-age state and no `NodeState` change; `non_repairable_rbd.py` is byte-identical to `master`. Tests are parametrized across AFT/PH/PO to prove the node is family-agnostic.
- **The one caveat:** `mean`/`random` require a proper parametric survival curve (`sf(0+) ≈ 1`, decaying to 0). A semiparametric Cox baseline is defined only on the observed range, so its MTTF is undefined and those two methods raise a clear, actionable error. `sf`, conditioning and importance work for all families.
- Distribution fitting stays in surpyval (per project scope); RePyability consumes the fitted model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUGaeQXKxjjiQ1ULT1ApXS

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUGaeQXKxjjiQ1ULT1ApXS)_