### PR TITLE
Add LoadSharingModel: load-sharing dynamic node (#38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`LoadSharingModel`: load-sharing dynamic node (dependent failure).** A
+  sibling to `StandbyModel` where *n* coupled units share a total load and the
+  survivors carry more (and so age faster) as siblings fail — the group works
+  while ≥ `k` survive. Each unit is a fitted AFT model, and a cumulative-exposure
+  event loop advances every unit's baseline clock at rate `phi(L / survivors)`.
+  Identical Exponential-baseline units get an exact hypoexponential closed form;
+  otherwise the survival function is a Kaplan-Meier fit to simulated lifetimes
+  (`is_simulated` reports which). With no load effect (`phi == 1`) the group
+  reduces exactly to the ordinary k-out-of-n parallel result. Plugs into an RBD
+  as a single simulation-backed node and serialises with it. (#38)
+
 ## [0.7.0] - 2026-07-20
 
 The **Maintenance & Covariates** milestone: price imperfect-repair (generalized

--- a/docs/api.md
+++ b/docs/api.md
@@ -17,6 +17,8 @@ the top-level `repyability` package).
 
 ::: repyability.StandbyModel
 
+::: repyability.LoadSharingModel
+
 ::: repyability.RepeatedNode
 
 ::: repyability.RepeatedStandbyNode

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -234,6 +234,44 @@ rbd.remaining_life(0.9, {"m": NodeState(age=40)})
   no defined MTTF and reports that clearly. Reliability, conditioning and
   importance work for all of them.
 
+## Load-sharing (dependent failure)
+
+Redundant units that *share a load* fail dependently: when one fails, the
+survivors pick up its share, run harder, and age faster — so the failures are
+correlated, not independent. A [`LoadSharingModel`][repyability.LoadSharingModel]
+captures this as a single RBD node (the units are coupled, so they can't be `n`
+independent nodes). It is the "self-loading" sibling of the condition-based
+layer: there the load is streamed from sensors, here it is computed from the
+group's own survivors (`L / s`).
+
+Each unit is a fitted AFT model (load as its covariate), so a survivor under
+load `L/s` ages at rate `φ(L/s)` on its baseline clock. The group works while at
+least `k` of `n` units survive:
+
+```python
+import surpyval as surv
+from repyability import NonRepairableRBD, LoadSharingModel
+
+# One AFT unit fitted with load as the covariate (higher load → shorter life)
+unit = surv.ExponentialAFT.fit(failure_times, Z=loads)
+
+# Three identical units share a total load of 3.0; the group needs ≥ 2
+group = LoadSharingModel([unit, unit, unit], load=3.0, k=2)
+
+rbd = NonRepairableRBD([("s", "g"), ("g", "t")], {"g": group})
+rbd.sf(50)      # group (and system) reliability
+group.mean()    # mean group lifetime
+```
+
+- **Exact where it can be:** identical units with an Exponential baseline give a
+  closed-form (hypoexponential) group lifetime; otherwise the survival function
+  is a Kaplan-Meier fit to simulated lifetimes (`is_simulated` reports which).
+- **Validation:** with no load effect (`φ ≡ 1`) the units neither share stress
+  nor accelerate, so the group reduces *exactly* to the ordinary k-out-of-n
+  parallel result.
+- Like any dynamic node it plugs into an RBD as a single simulation-backed node
+  and serialises with it (each unit round-trips via `surpyval.from_dict`).
+
 ## Repairable systems and availability
 
 A [`RepairableRBD`][repyability.RepairableRBD] takes components with both a

--- a/repyability/__init__.py
+++ b/repyability/__init__.py
@@ -13,6 +13,7 @@ from repyability.rbd.helper_classes import (
     PerfectReliability,
     PerfectUnreliability,
 )
+from repyability.rbd.load_sharing_node import LoadSharingModel
 from repyability.rbd.node_state import NodeState
 from repyability.rbd.non_repairable_rbd import NonRepairableRBD
 from repyability.rbd.rbd import RBD
@@ -44,6 +45,7 @@ __all__ = [
     "NonRepairable",
     "Repairable",
     "StandbyModel",
+    "LoadSharingModel",
     "RepeatedNode",
     "RepeatedStandbyNode",
     # Helpers

--- a/repyability/rbd/load_sharing_node.py
+++ b/repyability/rbd/load_sharing_node.py
@@ -1,0 +1,268 @@
+"""Load-sharing dynamic node: coupled units that share a load and age faster
+as siblings fail (dependent failure).
+
+*n* active units share a total load ``L``. While ``s`` of them survive, each
+carries load ``L / s`` and -- through its accelerated-failure-time (AFT)
+response -- ages at rate ``phi(L / s)`` on its baseline reliability clock. When
+a unit fails the survivors pick up its share, so they age *faster*; the group
+works while at least ``k`` units survive. Because the units are coupled (each
+unit's aging depends on how many siblings are alive), the group is a single RBD
+node -- it cannot be modelled as ``n`` independent nodes.
+
+This is the "self-loading" sibling of :class:`~repyability.StandbyModel`: the
+condition-based layer streams a component's load from sensors, whereas here the
+load is computed from the group's own survivors (``L / s``). See issue #38.
+
+Engine (per Monte-Carlo replicate) -- a cumulative-exposure event loop::
+
+    draw each unit's baseline exposure-to-failure threshold  tau_i
+    e_i = 0 (accumulated exposure);  t = 0
+    while >= k units survive:
+        phi_i = M_i.phi(L / survivors)      # aging rate under the load
+        dt    = min_i (tau_i - e_i) / phi_i  # real time to next failure
+        t    += dt;  e_i += phi_i * dt       # advance; accrue exposure
+        drop the failing unit
+    group lifetime = t
+
+For identical units with an Exponential baseline the group lifetime has an
+exact closed form (a hypoexponential distribution); otherwise the survival
+function is a Kaplan-Meier fit to simulated lifetimes (like ``StandbyModel``).
+"""
+
+import numpy as np
+from surpyval import KaplanMeier
+
+from repyability.utils.wrappers import conditional_survival, numpy_seed
+
+from ._model_utils import is_exponential
+
+_AFT_KIND = "Accelerated Failure Time"
+
+
+def _baseline(model):
+    """The AFT model's univariate baseline distribution ``R0`` (phi = 1)."""
+    return model.distribution.from_params(
+        [float(p) for p in np.atleast_1d(model.dist_params)]
+    )
+
+
+class _HypoexponentialSurvival:
+    """Survival function of a sum of independent Exponentials with *distinct*
+    rates (a hypoexponential / generalised-Erlang distribution).
+
+    For rates ``r_1, ..., r_m`` the survival is the partial-fraction sum
+    ``sf(t) = sum_j C_j exp(-r_j t)`` with ``C_j = prod_{l != j} r_l / (r_l -
+    r_j)`` (and ``sum_j C_j = 1``, so ``sf(0) = 1``). The mean is
+    ``sum_j 1 / r_j``.
+    """
+
+    def __init__(self, rates):
+        r = np.asarray(rates, dtype=float)
+        m = len(r)
+        coef = np.ones(m)
+        for j in range(m):
+            for ell in range(m):
+                if ell != j:
+                    coef[j] *= r[ell] / (r[ell] - r[j])
+        self.rates = r
+        self.coef = coef
+
+    def sf(self, x):
+        x = np.atleast_1d(np.asarray(x, dtype=float))
+        terms = self.coef[None, :] * np.exp(-self.rates[None, :] * x[:, None])
+        return np.clip(terms.sum(axis=1), 0.0, 1.0)
+
+    def ff(self, x):
+        return 1.0 - self.sf(x)
+
+    def mean(self, *args, **kwargs):
+        return float(np.sum(1.0 / self.rates))
+
+
+def _identical_exponential_stage_rates(models, load, k, baselines, phi_table):
+    """Stage failure rates for identical Exponential-baseline units, or None.
+
+    When every unit is the same AFT model with an Exponential baseline of rate
+    ``lambda``, the group passes through stages ``s = N, N-1, ..., k`` alive.
+    In stage ``s`` each survivor's residual exposure is Exponential
+    (memoryless) and accrues at rate ``phi(L / s)``, so its residual *time* is
+    ``Exponential(lambda * phi(L / s))`` and the ``s`` survivors' next failure
+    is ``Exponential(s * lambda * phi(L / s))``. The group lifetime sums these
+    independent stage times -- a hypoexponential with those rates. With
+    ``phi == 1`` the rates are ``s * lambda`` (``s = N..k``): exactly the
+    ``(N-k+1)``-th order statistic of ``N`` i.i.d. Exponentials, i.e. the
+    ordinary k-out-of-n parallel result.
+    """
+    n = len(models)
+    lam = None
+    for base in baselines:
+        if not is_exponential(base):
+            return None
+        mean = float(np.atleast_1d(base.mean())[0])
+        if mean <= 0.0:
+            return None
+        rate = 1.0 / mean
+        if lam is None:
+            lam = rate
+        elif not np.isclose(rate, lam):
+            return None
+    # phi must be identical across units at every stage for the closed form.
+    rates = []
+    for s in range(n, k - 1, -1):
+        phi_s = phi_table[0, s - 1]
+        if not np.allclose(phi_table[:, s - 1], phi_s):
+            return None
+        rates.append(s * lam * phi_s)
+    return np.asarray(rates, dtype=float)
+
+
+class LoadSharingModel:
+    """A load-sharing arrangement of coupled AFT units as one RBD node.
+
+    Parameters
+    ----------
+    models : sequence of fitted surpyval AFT models
+        The units. Each must be an accelerated-failure-time model fitted with
+        the (scalar) load as its covariate, exposing ``phi(load)`` and an AFT
+        baseline distribution.
+    load : float
+        The total load ``L`` shared by the active units. Each of ``s``
+        survivors carries ``L / s``.
+    k : int, optional
+        The minimum number of surviving units for the group to work, by default
+        1. The group fails at the ``(N - k + 1)``-th unit failure.
+    n_sims : int, optional
+        Monte-Carlo replicates for the Kaplan-Meier fit when no closed form
+        applies, by default 10_000.
+    lower : float, optional
+        ``set_lower_limit`` passed to the Kaplan-Meier fit, by default -inf.
+    seed : int or None, optional
+        Seed for the Monte-Carlo fit (reproducible), by default None.
+
+    Notes
+    -----
+    ``phi`` with no load effect (``phi == 1``) reproduces the ordinary
+    k-out-of-n parallel result exactly, since the units then neither share
+    stress nor age faster as siblings fail.
+    """
+
+    def __init__(
+        self,
+        models,
+        load,
+        k=1,
+        n_sims=10_000,
+        lower=-np.inf,
+        seed=None,
+    ):
+        models = list(models)
+        if len(models) == 0:
+            raise ValueError("LoadSharingModel needs at least one unit.")
+        if k < 1:
+            raise ValueError(f"k must be >= 1, got {k!r}.")
+        if k > len(models):
+            raise ValueError(
+                f"k ({k}) cannot exceed the number of units ({len(models)})."
+            )
+        for m in models:
+            if getattr(m, "kind", None) != _AFT_KIND:
+                raise ValueError(
+                    "LoadSharingModel units must be fitted accelerated-"
+                    "failure-time (AFT) models exposing phi(load); got "
+                    f"{type(m).__name__} with "
+                    f"kind={getattr(m, 'kind', None)!r}."
+                )
+        self.models = models
+        self.load = float(load)
+        self.k = int(k)
+        self.N = len(models)
+        self.n_sims = n_sims
+
+        self._baselines = [_baseline(m) for m in models]
+        # phi_table[i, s-1] = unit i's aging rate when s units share the load.
+        self._phi_table = np.array(
+            [
+                [
+                    float(np.ravel(m.phi(np.atleast_2d(self.load / s)))[0])
+                    for s in range(1, self.N + 1)
+                ]
+                for m in models
+            ]
+        )
+
+        rates = _identical_exponential_stage_rates(
+            models, self.load, self.k, self._baselines, self._phi_table
+        )
+        # The partial-fraction hypoexponential needs distinct rates; if a load
+        # effect collides two stage rates, fall back to the simulation path.
+        if rates is not None and _all_distinct(rates):
+            self._sf_model: object = _HypoexponentialSurvival(rates)
+            self.model = None
+        else:
+            x_random = self.random(n_sims, seed=seed)
+            self.model = KaplanMeier.fit(x_random, set_lower_limit=lower)
+            self._sf_model = None
+
+    def random(self, size, seed=None):
+        """Monte-Carlo simulate ``size`` group lifetimes via the cumulative-
+        exposure event loop."""
+        n, k, phi_tab = self.N, self.k, self._phi_table
+        with numpy_seed(seed):
+            # Baseline exposure-to-failure thresholds: (N, size).
+            tau = np.empty((n, size))
+            for i, base in enumerate(self._baselines):
+                tau[i] = np.asarray(base.random(size), dtype=float).reshape(-1)
+
+            out = np.empty(size)
+            for j in range(size):
+                thr = tau[:, j]
+                e = np.zeros(n)
+                alive = np.ones(n, dtype=bool)
+                t = 0.0
+                s = n
+                while s >= k:
+                    idx = np.flatnonzero(alive)
+                    phi = phi_tab[idx, s - 1]
+                    remaining = (thr[idx] - e[idx]) / phi
+                    w = int(np.argmin(remaining))
+                    dt = remaining[w]
+                    t += dt
+                    e[idx] += phi * dt
+                    alive[idx[w]] = False
+                    s -= 1
+                out[j] = t
+        return out
+
+    def mean(self, N=10_000, seed=None):
+        if self._sf_model is not None:
+            return self._sf_model.mean()
+        return float(self.random(N, seed=seed).mean())
+
+    def sf(self, *args, **kwargs):
+        if self._sf_model is not None:
+            return self._sf_model.sf(*args, **kwargs)
+        return self.model.sf(*args, **kwargs)
+
+    def ff(self, *args, **kwargs):
+        if self._sf_model is not None:
+            return self._sf_model.ff(*args, **kwargs)
+        return self.model.ff(*args, **kwargs)
+
+    def cs(self, x, X):
+        """Conditional survival ``R(x | X) = sf(X + x) / sf(X)``."""
+        return conditional_survival(self, x, X)
+
+    @property
+    def is_simulated(self) -> bool:
+        """True if the survival function is a Monte-Carlo (Kaplan-Meier) fit
+        rather than the exact hypoexponential closed form."""
+        return self._sf_model is None
+
+
+def _all_distinct(rates, rtol=1e-6):
+    r = np.sort(np.asarray(rates, dtype=float))
+    if len(r) < 2:
+        return True
+    gaps = np.diff(r)
+    scale = np.maximum(np.abs(r[:-1]), np.abs(r[1:]))
+    return bool(np.all(gaps > rtol * np.maximum(scale, 1e-12)))

--- a/repyability/rbd/non_repairable_rbd.py
+++ b/repyability/rbd/non_repairable_rbd.py
@@ -26,6 +26,7 @@ from repyability.utils.wrappers import conditional_survival, numpy_seed
 
 from ._model_utils import is_fixed_probability, parametric_spec
 from .helper_classes import PerfectReliability, PerfectUnreliability
+from .load_sharing_node import LoadSharingModel
 from .node_state import NodeState
 from .rbd import RBD
 from .repeated_node import RepeatedNode
@@ -251,7 +252,7 @@ class NonRepairableRBD(RBD):
                 continue
             else:
                 # when node is a Parametric model
-                if isinstance(node, StandbyModel):
+                if isinstance(node, (StandbyModel, LoadSharingModel)):
                     fixed_flags = [False]
                     break
                 elif isinstance(node, RepeatedNode):
@@ -571,7 +572,11 @@ class NonRepairableRBD(RBD):
     # standby arrangement is sequence-dependent (dynamic), so its sf(t) cannot
     # be expressed analytically and is instead estimated by simulation. Such
     # nodes therefore prevent a purely analytic / BDD solution of the system.
-    _SIMULATION_NODE_TYPES = (StandbyModel, RepeatedStandbyNode)
+    _SIMULATION_NODE_TYPES = (
+        StandbyModel,
+        RepeatedStandbyNode,
+        LoadSharingModel,
+    )
 
     def _node_is_analytic(self, model) -> bool:
         """Returns True if a node's reliability is available without
@@ -871,7 +876,14 @@ class NonRepairableRBD(RBD):
         out of scope for condition-based evaluation in this release.
         """
         return not isinstance(
-            model, (StandbyModel, RepeatedStandbyNode, RepeatedNode, RBD)
+            model,
+            (
+                StandbyModel,
+                RepeatedStandbyNode,
+                LoadSharingModel,
+                RepeatedNode,
+                RBD,
+            ),
         )
 
     def _validate_state(self, state) -> None:
@@ -1119,7 +1131,13 @@ class NonRepairableRBD(RBD):
             for node in self.nodes:
                 model = self.reliabilities[node]
                 if isinstance(
-                    model, (StandbyModel, NonRepairableRBD, RepeatedNode)
+                    model,
+                    (
+                        StandbyModel,
+                        LoadSharingModel,
+                        NonRepairableRBD,
+                        RepeatedNode,
+                    ),
                 ):
                     out[node] = float(np.atleast_1d(model.mean(mc_samples))[0])
                 elif is_fixed_probability(model):

--- a/repyability/rbd/serialisation.py
+++ b/repyability/rbd/serialisation.py
@@ -33,6 +33,7 @@ from repyability.rbd.helper_classes import (
     PerfectReliability,
     PerfectUnreliability,
 )
+from repyability.rbd.load_sharing_node import LoadSharingModel
 from repyability.rbd.rbd import RBD
 from repyability.rbd.regression_node import RegressionNode
 from repyability.rbd.repeated_node import PARALLEL, RepeatedNode
@@ -84,6 +85,14 @@ def serialise_model(model: Any) -> dict:
         }
     if isinstance(model, RegressionNode):
         return {"kind": "regression_node", **model.to_dict()}
+    if isinstance(model, LoadSharingModel):
+        return {
+            "kind": "load_sharing",
+            "models": [m.to_dict() for m in model.models],
+            "load": model.load,
+            "k": model.k,
+            "n_sims": model.n_sims,
+        }
     dist = distribution_name(model)
     if dist is not None:
         return {
@@ -140,6 +149,13 @@ def deserialise_model(d: dict) -> Any:
         )
     if kind == "regression_node":
         return RegressionNode.from_dict(d)
+    if kind == "load_sharing":
+        return LoadSharingModel(
+            [surpyval.from_dict(md) for md in d["models"]],
+            load=d["load"],
+            k=d["k"],
+            n_sims=d.get("n_sims", 10_000),
+        )
     raise ValueError(f"Unknown model kind {kind!r}.")
 
 

--- a/repyability/tests/test_load_sharing.py
+++ b/repyability/tests/test_load_sharing.py
@@ -1,0 +1,155 @@
+"""Tests for the load-sharing dynamic node (issue #38): coupled units that
+share a load and age faster as siblings fail.
+
+The exact anchor is the ``phi == 1`` limit (no load effect), where the group
+lifetime is the ``(N-k+1)``-th order statistic of ``N`` i.i.d. Exponentials --
+the ordinary k-out-of-n parallel result -- which the hypoexponential closed
+form must reproduce exactly.
+"""
+
+import numpy as np
+import pytest
+import surpyval as surv
+from scipy.special import comb
+
+from repyability import LoadSharingModel, NonRepairableRBD
+from repyability.rbd.load_sharing_node import _HypoexponentialSurvival
+
+
+@pytest.fixture(scope="module")
+def exp_aft():
+    """An Exponential-AFT unit fitted with load as the covariate (higher load
+    -> shorter life), so the identical-unit closed form applies."""
+    rng = np.random.default_rng(0)
+    load = rng.uniform(0.5, 2.0, size=800)
+    x = rng.exponential(scale=100.0 / np.exp(0.6 * (load - 1.0)), size=800)
+    return surv.ExponentialAFT.fit(x + 1e-3, Z=load.reshape(-1, 1))
+
+
+def _k_of_n_sf(t, n, k, lam):
+    """P(>= k of n i.i.d. Exp(lam) units still alive at t)."""
+    p = np.exp(-lam * t)
+    return sum(comb(n, j) * p**j * (1 - p) ** (n - j) for j in range(k, n + 1))
+
+
+# -- exact validation: phi == 1 reproduces k-out-of-n --------------------
+
+
+@pytest.mark.parametrize("k", [1, 2, 3])
+def test_phi1_hypoexponential_is_exact_k_of_n(k):
+    # With no load effect the stage rates are s*lambda (s = N..k); the
+    # hypoexponential of those rates is exactly the (N-k+1)-th order statistic
+    # of N i.i.d. Exponentials.
+    lam, n = 0.02, 4
+    rates = np.array([s * lam for s in range(n, k - 1, -1)])
+    hypo = _HypoexponentialSurvival(rates)
+    t = np.array([10.0, 40.0, 90.0, 180.0])
+    expected = np.array([_k_of_n_sf(ti, n, k, lam) for ti in t])
+    assert np.allclose(hypo.sf(t), expected)
+    assert hypo.sf(np.array([0.0]))[0] == pytest.approx(1.0)
+    # mean of the hypoexponential = sum 1/rate
+    assert hypo.mean() == pytest.approx(np.sum(1.0 / rates))
+
+
+# -- closed form <-> Monte-Carlo agreement --------------------------------
+
+
+def test_closed_form_matches_monte_carlo(exp_aft):
+    ls = LoadSharingModel([exp_aft] * 3, load=3.0, k=1)
+    assert ls.is_simulated is False  # identical Exp baseline -> closed form
+    mc = surv.KaplanMeier.fit(ls.random(15000, seed=1))
+    t = np.array([40.0, 120.0, 300.0])
+    assert np.allclose(ls.sf(t), mc.sf(t), atol=0.025)
+
+
+def test_reproducible_with_seed(exp_aft):
+    # A Weibull baseline forces the Monte-Carlo (Kaplan-Meier) path.
+    rng = np.random.default_rng(1)
+    load = rng.uniform(0.5, 2.0, size=400)
+    x = rng.weibull(2.0, size=400) * 80.0 / np.exp(0.4 * (load - 1)) + 1e-3
+    waft = surv.WeibullAFT.fit(x, Z=load.reshape(-1, 1))
+    a = LoadSharingModel([waft, waft], load=2.0, k=1, n_sims=500, seed=7)
+    b = LoadSharingModel([waft, waft], load=2.0, k=1, n_sims=500, seed=7)
+    assert a.is_simulated is True
+    t = np.array([30.0, 90.0])
+    assert np.allclose(a.sf(t), b.sf(t))
+
+
+# -- dependent failure: sharing shortens life -----------------------------
+
+
+def test_more_shared_load_shortens_life(exp_aft):
+    light = LoadSharingModel([exp_aft] * 3, load=1.5, k=1).mean()
+    heavy = LoadSharingModel([exp_aft] * 3, load=6.0, k=1).mean()
+    assert heavy < light
+
+
+def test_higher_k_shortens_life(exp_aft):
+    # Needing more survivors (higher k) fails the group sooner.
+    k1 = LoadSharingModel([exp_aft] * 3, load=3.0, k=1).mean()
+    k3 = LoadSharingModel([exp_aft] * 3, load=3.0, k=3).mean()
+    assert k3 < k1
+
+
+def test_is_simulated_flag(exp_aft):
+    # Identical Exponential baseline -> exact closed form.
+    assert LoadSharingModel([exp_aft] * 2, load=2.0).is_simulated is False
+
+
+# -- inside an RBD --------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def rbd(exp_aft):
+    grp = LoadSharingModel([exp_aft] * 3, load=3.0, k=2)
+    return NonRepairableRBD(
+        [("s", "g"), ("g", "c"), ("c", "t")],
+        {"g": grp, "c": surv.Weibull.from_params([300.0, 2.0])},
+    )
+
+
+def test_rbd_is_time_varying_and_non_analytic(rbd):
+    assert rbd.is_time_varying
+    assert rbd.is_analytically_solvable() is False  # a simulation node
+
+
+def test_rbd_evaluates_and_mttf(rbd):
+    assert 0.0 < float(rbd.sf(60.0)) < 1.0
+    assert rbd.mean(2000, seed=1) > 0.0
+    mttf = rbd.node_mttf(mc_samples=1500, seed=1)
+    assert mttf["g"] > 0.0 and mttf["c"] > 0.0
+
+
+# -- serialisation --------------------------------------------------------
+
+
+def test_rbd_with_load_sharing_json_roundtrip(rbd):
+    restored = NonRepairableRBD.from_json(rbd.to_json())
+    g = restored.reliabilities["g"]
+    assert isinstance(g, LoadSharingModel)
+    assert g.load == 3.0 and g.k == 2 and g.N == 3
+    t = np.array([40.0, 120.0])
+    np.testing.assert_allclose(
+        restored.reliabilities["g"].sf(t),
+        rbd.reliabilities["g"].sf(t),
+    )
+
+
+# -- construction validation ----------------------------------------------
+
+
+def test_non_aft_unit_rejected():
+    with pytest.raises(ValueError, match="accelerated-failure-time|AFT"):
+        LoadSharingModel([surv.Weibull.from_params([100.0, 2.0])], load=1.0)
+
+
+def test_k_bounds(exp_aft):
+    with pytest.raises(ValueError, match="k"):
+        LoadSharingModel([exp_aft, exp_aft], load=1.0, k=3)
+    with pytest.raises(ValueError, match="k"):
+        LoadSharingModel([exp_aft], load=1.0, k=0)
+
+
+def test_empty_units_rejected():
+    with pytest.raises(ValueError, match="at least one"):
+        LoadSharingModel([], load=1.0)


### PR DESCRIPTION
## Summary

Adds `LoadSharingModel` (#38): a dynamic RBD node for **load-sharing / dependent failure**, a sibling to `StandbyModel`. *n* coupled units share a total load; when one fails the survivors carry more (`L / s`) and — through their AFT `phi(load)` response — age faster. The group works while ≥ `k` of `n` survive. Because the units are coupled, the group is a single node (it can't be `n` independent nodes).

**Engine** — a cumulative-exposure event loop (per Monte-Carlo replicate): draw each unit's baseline exposure-to-failure threshold, advance every survivor's baseline clock at rate `phi(L / survivors)`, drop the first to reach its threshold, repeat until fewer than `k` survive.

This is the "self-loading" sibling of the condition-based layer: same conditional-survival engine, but the load comes from the group's own survivors rather than from sensors.

- New `repyability/rbd/load_sharing_node.py`: `sf`/`ff`/`mean`/`random`/`cs`. Identical Exponential-baseline units get an **exact hypoexponential closed form** (stage rates `s·λ·phi(L/s)`); otherwise the survival is a Kaplan-Meier fit to simulated lifetimes (`is_simulated` reports which).
- Wired into `NonRepairableRBD` exactly like `StandbyModel` (simulation node, time-varying, non-stateable, `node_mttf`), RBD (de)serialisation, and exported from the package.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Refactor / tooling
- [ ] Breaking change

## Checklist

- [x] Tests added/updated (asserting against a reference value where possible)
- [x] `black`, `isort`, `flake8`, and `mypy` pass
- [x] `coverage run -m pytest` passes and stays above the coverage gate
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Any Monte-Carlo tests are seeded (deterministic)

## Notes for reviewers

- **Exactness anchor:** with no load effect (`phi ≡ 1`) the stage rates become `s·λ` and the closed form is *exactly* the `(N-k+1)`-th order statistic of `N` i.i.d. Exponentials — the ordinary k-out-of-n parallel result. A test checks this against the binomial-sum formula, and closed-form vs Monte-Carlo agreement is tested for the load-dependent case.
- **AFT-specific by design:** the exposure clock relies on the AFT time-scale property, so units are fitted surpyval AFT models fitted with load as the covariate. This is the same `phi`/exposure machinery kept internal here — it does not touch the public `RegressionNode`/`NodeState` API.
- Distribution fitting stays in surpyval; RePyability consumes the fitted models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUGaeQXKxjjiQ1ULT1ApXS

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUGaeQXKxjjiQ1ULT1ApXS)_