### PR TITLE
Release 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-07-22
+
+The **Dependent Failures** milestone: model redundant components that fail
+*together* or *drive each other's aging*, rather than independently — load-
+sharing groups whose survivors carry more and age faster as siblings fail
+(`LoadSharingModel`), common-cause failures through the beta-factor and Multiple
+Greek Letter models (`CCFGroup`), and covariate loads that vary over a
+component's life (`RegressionNode` schedules, built on surpyval 0.16's
+`sf_tvc`).
+
 ### Added
 - **Time-varying load for `RegressionNode` (load-dependent aging, #37).**
   `RegressionNode` now accepts a `schedule=` (a surpyval `StepSchedule`) as an

--- a/repyability/_version.py
+++ b/repyability/_version.py
@@ -5,4 +5,4 @@ Kept deliberately free of imports so the build backend can read
 dependencies) via ``[tool.setuptools.dynamic]`` in ``pyproject.toml``.
 """
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"


### PR DESCRIPTION
## Summary

Cuts the **0.8.0** release: bumps `repyability/_version.py` to `0.8.0` and rolls
the CHANGELOG `[Unreleased]` section into a dated `[0.8.0] - 2026-07-22` entry —
the **Dependent Failures** milestone (load sharing `LoadSharingModel`,
common-cause `CCFGroup`, and time-varying-load `RegressionNode` schedules). No
code changes; the features (#37, #38, #44) are already on `master`.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor / tooling (release / version bump)
- [ ] Breaking change

## Checklist

- [x] Tests added/updated — n/a (version + CHANGELOG only; the feature tests are already on `master`)
- [x] `black`, `isort`, `flake8`, and `mypy` pass
- [x] `coverage run -m pytest` passes and stays above the coverage gate
- [x] `CHANGELOG.md` updated — `[Unreleased]` rolled into `[0.8.0] - 2026-07-22`
- [x] Any Monte-Carlo tests are seeded — n/a

## Notes for reviewers

- After this merges, cut the release by tagging `v0.8.0` on the merge commit and publishing a GitHub Release for it; `release.yml` then builds and publishes to PyPI via trusted publishing (OIDC). `_version.py` (`0.8.0`) and the tag (`v0.8.0`) must stay in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUGaeQXKxjjiQ1ULT1ApXS

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUGaeQXKxjjiQ1ULT1ApXS)_